### PR TITLE
Add the necessary well_formedness properties to L2/L3 and correct tra…

### DIFF
--- a/theories/L2k_noCnstrParams/compile.v
+++ b/theories/L2k_noCnstrParams/compile.v
@@ -389,11 +389,13 @@ Qed.
 (** environments and programs **)
 Function stripEC (ec:L2EC) : AstCommon.envClass Term :=
   match ec with
-    | ecTrm t => ecTrm (strip t)
-    | ecTyp _ n itp => ecTyp Term n itp
+  | ecTrm t => ecTrm (strip t)
+  | ecTyp _ n itp =>
+    (** We stripped the parameters of all constructors *)
+    ecTyp Term 0 itp
   end.
 
-Definition  stripEnv : L2Env -> AstCommon.environ Term :=
+Definition stripEnv : L2Env -> AstCommon.environ Term :=
   List.map (fun nmec : string * L2EC => (fst nmec, stripEC (snd nmec))).
 
 Lemma stripEcTrm_hom:

--- a/theories/L2k_noCnstrParams/program.v
+++ b/theories/L2k_noCnstrParams/program.v
@@ -107,8 +107,8 @@ with crctEnv: environ Term -> Prop :=
 | ceNil: crctEnv nil
 | ceTrmCons: forall nm s p,
     crctEnv p -> fresh nm p -> crctTerm p 0 s -> crctEnv ((nm, ecTrm s)::p)
-| ceTypCons: forall nm m s p,
-    crctEnv p -> fresh nm p -> crctEnv ((nm, ecTyp Term m s)::p)
+| ceTypCons: forall nm s p,
+    crctEnv p -> fresh nm p -> crctEnv ((nm, ecTyp Term 0 s)::p)
 with crctTerms: environ Term -> nat -> Terms -> Prop :=
 | ctsNil: forall p n, crctEnv p -> crctTerms p n tnil
 | ctsCons: forall p n t ts,
@@ -237,17 +237,17 @@ Qed.
 
 Lemma Crct_weaken_Typ:
   (forall p n t, crctTerm p n t -> 
-                 forall nm s m, fresh nm p ->
-                              crctTerm ((nm,ecTyp Term m s)::p) n t) /\
+                 forall nm s, fresh nm p ->
+                              crctTerm ((nm,ecTyp Term 0 s)::p) n t) /\
   (forall p n ts, crctTerms p n ts -> 
-                  forall nm s m, fresh nm p ->
-                               crctTerms ((nm,ecTyp Term m s)::p) n ts) /\
+                  forall nm s, fresh nm p ->
+                               crctTerms ((nm,ecTyp Term 0 s)::p) n ts) /\
   (forall p n ts, crctBs p n ts -> 
-                  forall nm s m, fresh nm p ->
-                               crctBs ((nm,ecTyp Term m s)::p) n ts) /\
+                  forall nm s, fresh nm p ->
+                               crctBs ((nm,ecTyp Term 0 s)::p) n ts) /\
   (forall p n ds, crctDs p n ds -> 
-                  forall nm s m, fresh nm p ->
-                               crctDs ((nm,ecTyp Term m s)::p) n ds) /\
+                  forall nm s, fresh nm p ->
+                               crctDs ((nm,ecTyp Term 0 s)::p) n ds) /\
   (forall p, crctEnv p -> True).
 Proof.
   apply crctCrctsCrctBsDsEnv_ind; intros;

--- a/theories/L3_flattenedApp/term.v
+++ b/theories/L3_flattenedApp/term.v
@@ -608,6 +608,7 @@ Inductive PoccTrm : Term -> Prop :=
 | PoConst: PoccTrm (TConst nm)
 | PoCaseL: forall i mch brs, PoccTrm mch -> PoccTrm (TCase i mch brs)
 | PoCaseR: forall i mch brs, PoccBrs brs -> PoccTrm (TCase i mch brs)
+| PoCaseAnn: forall k mch brs, PoccTrm (TCase (mkInd nm k) mch brs)
 | PoFix: forall ds m, PoccDefs ds -> PoccTrm (TFix ds m)
 | PoCnstrI: forall m1 m2 args,
               PoccTrm (TConstruct (mkInd nm m1) m2 args)
@@ -910,6 +911,7 @@ Proof.
   - inversion_Clear H1.
     + apply PoCaseL. intuition.
     + apply PoCaseR. intuition.
+    + apply PoCaseAnn. 
   - inversion_Clear H1.
     + constructor. intuition.
     + apply PoTtl. intuition.

--- a/theories/L3_flattenedApp/wcbvEval.v
+++ b/theories/L3_flattenedApp/wcbvEval.v
@@ -221,7 +221,7 @@ Proof.
     + apply (dnthBody_pres_Crct _ e). eapply CrctDs_Up. eassumption. 
       rewrite list_to_zero_length. omega.
   - apply H0. eapply whCaseStep_pres_Crct; try eassumption.
-    specialize (H _ H6). inversion_Clear H. assumption.
+    specialize (H _ H7). inversion_Clear H. assumption.
 Qed.
 
 Lemma WcbvEval_mkApp_WcbvEval:

--- a/theories/L4_deBruijn/L3_to_L3_eta.v
+++ b/theories/L4_deBruijn/L3_to_L3_eta.v
@@ -22,7 +22,6 @@ Ltac forward H :=
 Import L3t.
 
 Section TermTranslation.
-    
 
   Fixpoint is_n_lambda n t :=
     match n with
@@ -95,7 +94,6 @@ Section TermTranslation.
     | dnil => dnil
     | dcons na t n ds => dcons na (trans k t) n (trans_fixes k ds)
     end.
-
   
 End TermTranslation.
 
@@ -113,6 +111,7 @@ Fixpoint transEnv (p:environ Term) : environ Term :=
     | cons (nm, ec) q => cons (nm, transEC ec) (transEnv q)
   end.
 
+
 Lemma Lookup_trans_env e nm t : LookupDfn nm e t -> LookupDfn nm (transEnv e) (trans 0 t).
 Proof.
   red. intros H. red in H.
@@ -128,31 +127,33 @@ Proof.
   now apply (H1 t).
 Qed.
 
-Inductive match_annot : list Cnstr -> Brs -> Prop :=
-| match_annot_nil : match_annot [] bnil
-| match_annot_cons t args c cnstrs ds :
-    c.(CnstrArity) = args ->
-    match_annot cnstrs ds ->
-    match_annot (c :: cnstrs) (bcons args t ds).
-         
-Definition crctAnn (e : environ Term) ann brs :=
-  let 'mkInd nm tndx := ann in
-  exists pack ityp,
-    LookupTyp nm e 0 pack /\
-    getInd pack tndx = Ret ityp /\
-    match_annot ityp.(itypCnstrs) brs.
-
 Lemma Crct_invrt_Case e n ann mch brs :
   crctTerm e n (TCase ann mch brs) ->
   crctTerm e n mch /\ crctBs e n brs /\
-  crctAnn e ann brs /\
+  crctAnnot e ann brs /\
   (forall i t, bnth i brs = Some t -> crctTerm e n (fst t)).
-Admitted.
+Proof.
+  intros.
+  apply Crct_invrt_Case in H. intuition. clear H2.
+  revert H i t H1.
+  induction 1; simpl; intros; try discriminate.
+  destruct i. injection H2 as <-; auto.
+  eapply IHcrctBs; eauto.
+Qed.
 
 Lemma Crct_construct {e : environ Term} {i n args} : crctEnv e ->
   crctTerm e 0 (TConstruct i n args) ->
   cnstrArity e i n = Ret (0%nat, tlength args).
-Proof. intros. inv H. Admitted.
+Proof.
+  intros.
+  destruct i.
+  apply Crct_invrt_Construct in H0 as (crctArgs&itypk&Hlook&ip&Hip&ctr&Hctr&Hargs).
+  unfold cnstrArity.
+  destruct Hlook as [Hlook Hne].
+  apply Lookup_lookup in Hlook.
+  unfold lookupTyp. rewrite Hlook. destruct itypk. elim Hne; reflexivity.
+  rewrite Hip, Hctr. unfold ret. repeat f_equal. assumption.
+Qed.
 
 Lemma bnth_trans n t i brs :
   bnth n brs = Some t -> exists t',
@@ -311,7 +312,7 @@ Proof.
 Qed.
 
 Lemma whCase_step e i n args brs cs s :
-  crctEnv e -> crctBs e 0 brs -> crctAnn e i brs -> crctTerms e 0 args ->
+  crctEnv e -> crctBs e 0 brs -> crctAnnot e i brs -> crctTerms e 0 args ->
   cnstrArity e i n = Ret (0%nat, tlength args) ->
   whCaseStep n args brs = Some cs -> WcbvEval e cs s ->
   WcbvEvals (transEnv e) (trans_terms 0 args) (trans_terms 0 args) ->
@@ -333,7 +334,7 @@ Proof.
   destruct p. simpl in *.
   injection Hdn. intros -> ->.
   assert(tlength args = arg).
-  { unfold crctAnn in *. destruct i as [nm ndx].
+  { unfold crctAnnot in *. destruct i as [nm ndx].
     destruct crctann as [pack [ityp [Hlook [Hind Hann]]]].
     unfold cnstrArity in crctar. red in Hlook. destruct Hlook as [Hlook none].
     apply Lookup_lookup in Hlook. unfold lookupTyp in *. rewrite Hlook in crctar.
@@ -492,12 +493,15 @@ Proof.
     eapply IHcs; eauto.
     eapply whCaseStep_pres_Crct in Hcase; eauto.
     apply wcbvEval_construct in IHmch; eauto.
-    admit. (* Well-formedness preserved by trans *) admit. admit.
+    admit. (* Well-formedness preserved by trans *) admit.
+    eapply WcbvEval_pres_Crct in evmch; eauto.
+    now apply Crct_construct in evmch.
     eapply WcbvEval_pres_Crct in evmch; eauto.
     destruct i. now eapply Crct_invrt_Construct in evmch as [Hargs _].
     
-  - intros * evmch IHmch. admit.
-    (* Stuck matches are impossible *)
+  - intros * evmch IHmch. intros.
+    inv H1.
+    constructor; auto. 
   - intros. apply H; auto.
 Admitted.
     


### PR DESCRIPTION
…nslation

- L2k strips params, so the entries for all inductives in the environment
  have their parameters turned to 0, this is reflected in the well-formedness
  predicate of terms and environments resulting from that translation.
- In L3, for correct terms, the inductive annotation on cases matches some
  inductive declaration in the environment, and branches of the case
  have arities as declared in the environment.
  This correctness criterion is preserved by everything, as proven.

Using these last bits, I'm able to finish the L3-L4 phase proofs.

@rpollack0 does it look ok to you? What this means is that above L3 you'll need to add matching crctAnnot conditions in well-formedness predicates ensuring that the cases we see correspond to inductive declarations in the environment. It should be really straightforward as these annotations are untouched by translations as far as I know.