### PR TITLE
Adapt to MetaRocq PR #1272

### DIFF
--- a/plugins/common/certirocq_options.ml
+++ b/plugins/common/certirocq_options.ml
@@ -1,5 +1,6 @@
 type command_args =
  | TYPED_ERASURE
+ | NO_INLINING
  | UNSAFE_ERASURE
  | BYPASS_QED
  | CPS
@@ -24,6 +25,7 @@ type extract_inductives = (Kernames.kername * extract_inductive list) list
 
 type options =
   { typed_erasure : bool;
+    no_inlining : bool;
     unsafe_erasure : bool;
     bypass_qed : bool;
     cps : bool;
@@ -55,6 +57,7 @@ let check_build_dir d =
 
 let default_options ~build_dir ~inductives_mapping ~extracted_inductives () : options =
   { typed_erasure = false;
+    no_inlining = false;
     unsafe_erasure = false;
     bypass_qed = false;
     cps = false;
@@ -79,6 +82,7 @@ let make_options ~build_dir ~inductives_mapping ~extracted_inductives
     match l with
     | [] -> o
     | TYPED_ERASURE :: xs -> aux {o with typed_erasure = true} xs
+    | NO_INLINING :: xs -> aux {o with no_inlining = true} xs
     | UNSAFE_ERASURE :: xs -> aux {o with unsafe_erasure = true} xs
     | BYPASS_QED :: xs -> aux {o with bypass_qed = true} xs
     | CPS :: xs -> aux {o with cps = true} xs

--- a/plugins/common/certirocq_options.mli
+++ b/plugins/common/certirocq_options.mli
@@ -1,5 +1,6 @@
 type command_args =
  | TYPED_ERASURE
+ | NO_INLINING
  | UNSAFE_ERASURE
  | BYPASS_QED
  | CPS
@@ -24,6 +25,7 @@ type extract_inductives = (Kernames.kername * extract_inductive list) list
 
 type options =
   { typed_erasure : bool;
+    no_inlining : bool;
     unsafe_erasure : bool;
     bypass_qed : bool;
     cps : bool;

--- a/plugins/cplugin/certirocq.ml
+++ b/plugins/cplugin/certirocq.ml
@@ -244,7 +244,6 @@ let make_options (l : command_args list) (pr : prim list) (fname : string) : opt
 let make_unsafe_passes b =
   let open Erasure0 in
   { cofix_to_lazy = b;
-    inlining = b;
     unboxing = b;
     betared = b;
     inductives_extraction = b }
@@ -267,6 +266,7 @@ let make_pipeline_options (opts : options) =
         enable_typed_erasure = opts.typed_erasure;
         enable_unsafe = if opts.unsafe_erasure then all_unsafe_passes else no_unsafe_passes;
         dearging_config = default_dearging_config;
+        inlining = not (opts.no_inlining);
         inlined_constants = Kernames.KernameSet.empty;
         extracted_inductives = Obj.magic opts.extracted_inductives; (* kername and list representation are the same *)
         })

--- a/plugins/plugin/certirocq.ml
+++ b/plugins/plugin/certirocq.ml
@@ -239,7 +239,6 @@ let make_options (l : command_args list) (pr : prim list) (fname : string) : opt
 let make_unsafe_passes b =
   let open Erasure0 in
   { cofix_to_lazy = b;
-    inlining = b;
     unboxing = b;
     betared = b;
     inductives_extraction = b }
@@ -261,6 +260,7 @@ let make_pipeline_options (opts : options) =
       Erasure0.({
         enable_typed_erasure = opts.typed_erasure;
         enable_unsafe = if opts.unsafe_erasure then all_unsafe_passes else no_unsafe_passes;
+        inlining = not (opts.no_inlining);
         dearging_config = default_dearging_config;
         inlined_constants = Kernames.KernameSet.empty;
         extracted_inductives = Obj.magic opts.extracted_inductives; (* kername and list representation are the same *)


### PR DESCRIPTION
Inlining is now a verified pass, switchable by an option (default is to allow inlining). Inlined constants should be registered (to come in a later PR)