### PR TITLE
Metarocq full pipeline

### DIFF
--- a/.github/workflows/nix-action-default.yml
+++ b/.github/workflows/nix-action-default.yml
@@ -289,4 +289,4 @@ on:
     - reopened
   push:
     branches:
-    - master
+    - main

--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -34,7 +34,7 @@
     };
   };
 
-  bundles."default".push-branches = ["master"];
+  bundles."default".push-branches = ["main"];
 
   ## Cachix caches to use in CI
   ## Below we list some standard ones

--- a/plugins/cplugin/_CoqProject
+++ b/plugins/cplugin/_CoqProject
@@ -143,6 +143,8 @@ extraction/eCSubst.ml
 extraction/eCSubst.mli
 extraction/eCoInductiveToInductive.ml
 extraction/eCoInductiveToInductive.mli
+extraction/eConstantsToValues.ml
+extraction/eConstantsToValues.mli
 extraction/eConstructorsAsBlocks.ml
 extraction/eConstructorsAsBlocks.mli
 extraction/eEnvMap.ml
@@ -151,6 +153,10 @@ extraction/eEtaExpanded.ml
 extraction/eEtaExpanded.mli
 extraction/eGlobalEnv.ml
 extraction/eGlobalEnv.mli
+extraction/eImplementBox.ml
+extraction/eImplementBox.mli
+extraction/eImplementLazyForce.ml
+extraction/eImplementLazyForce.mli
 extraction/eInduction.ml
 extraction/eInduction.mli
 extraction/eInlineProjections.ml
@@ -311,6 +317,8 @@ extraction/memory.ml
 extraction/memory.mli
 extraction/memtype.ml
 extraction/memtype.mli
+extraction/metarocq_pipeline.ml
+extraction/metarocq_pipeline.mli
 extraction/monad0.ml
 extraction/monad0.mli
 extraction/monadExc.ml

--- a/plugins/cplugin/certirocq_vanilla_plugin.mlpack
+++ b/plugins/cplugin/certirocq_vanilla_plugin.mlpack
@@ -167,6 +167,9 @@ EReorderCstrs
 ERemapInductives
 EBeta
 ECoInductiveToInductive
+EImplementBox
+EImplementLazyForce
+EConstantsToValues
 ETransform
 Erasure0
 
@@ -244,6 +247,7 @@ Toplevel
 Toplevel0
 Glue_utils
 Glue
+Metarocq_pipeline
 Pipeline
 Plugin_utils
 Certirocq

--- a/plugins/manifests/plugin-manifest
+++ b/plugins/manifests/plugin-manifest
@@ -227,6 +227,9 @@ EReorderCstrs
 ERemapInductives
 EBeta
 ECoInductiveToInductive
+EImplementBox
+EImplementLazyForce
+EConstantsToValues
 ETransform
 Erasure0
 
@@ -322,6 +325,7 @@ LambdaANF_to_Wasm :: plugin
 Toplevel1 :: plugin
 Glue_utils
 Glue
+Metarocq_pipeline
 Pipeline
 Plugin_utils :: cplugin
 Certirocq

--- a/plugins/plugin/_CoqProject
+++ b/plugins/plugin/_CoqProject
@@ -149,6 +149,8 @@ extraction/eCSubst.ml
 extraction/eCSubst.mli
 extraction/eCoInductiveToInductive.ml
 extraction/eCoInductiveToInductive.mli
+extraction/eConstantsToValues.ml
+extraction/eConstantsToValues.mli
 extraction/eConstructorsAsBlocks.ml
 extraction/eConstructorsAsBlocks.mli
 extraction/eEnvMap.ml
@@ -157,6 +159,10 @@ extraction/eEtaExpanded.ml
 extraction/eEtaExpanded.mli
 extraction/eGlobalEnv.ml
 extraction/eGlobalEnv.mli
+extraction/eImplementBox.ml
+extraction/eImplementBox.mli
+extraction/eImplementLazyForce.ml
+extraction/eImplementLazyForce.mli
 extraction/eInduction.ml
 extraction/eInduction.mli
 extraction/eInlineProjections.ml
@@ -331,6 +337,8 @@ extraction/memory0.ml
 extraction/memory0.mli
 extraction/memtype.ml
 extraction/memtype.mli
+extraction/metarocq_pipeline.ml
+extraction/metarocq_pipeline.mli
 extraction/monad0.ml
 extraction/monad0.mli
 extraction/monadExc.ml

--- a/plugins/plugin/certirocq_plugin.mlpack
+++ b/plugins/plugin/certirocq_plugin.mlpack
@@ -164,6 +164,9 @@ EReorderCstrs
 ERemapInductives
 EBeta
 ECoInductiveToInductive
+EImplementBox
+EImplementLazyForce
+EConstantsToValues
 ETransform
 Erasure0
 
@@ -259,6 +262,7 @@ LambdaANF_to_Wasm
 Toplevel1
 Glue_utils
 Glue
+Metarocq_pipeline
 Pipeline
 Certirocq
 G_certirocq

--- a/theories/Compiler/metarocq_pipeline.v
+++ b/theories/Compiler/metarocq_pipeline.v
@@ -1,0 +1,80 @@
+Require Import Common.Common Common.compM Common.Pipeline_utils.
+From Stdlib Require Import List.
+Require Import maps_util.
+Require Import MetaRocq.Common.BasicAst.
+From MetaRocq.Erasure Require Import EAst Erasure.
+From MetaRocq.ErasurePlugin Require Import Erasure.
+From MetaRocq.Utils Require Import MRString.
+
+Import Monads.
+Import MonadNotation.
+Import ListNotations.
+
+From MetaRocq.Erasure Require Import EProgram ERemapInductives EBeta.
+From MetaRocq.Common Require Import Transform.
+From MetaRocq.ErasurePlugin Require Import ETransform.
+Import Transform.
+
+Import EWellformed.
+From MetaRocq.Erasure Require Import EImplementBox EImplementLazyForce.
+Import TemplateProgram.
+
+(** The CertiRocq MetaRocq pipeline is composed of the verified typed or untyped MetaRocq pipelines plus:
+
+    - CoFixpoints to fixpoints (unverified, only relevant if the source term contains cofixpoints)
+    - Transformation of constants to values (verified, simplifies the ANF proof)
+    - Transformation of lazy/force to lambda abstractions and applications (verified)
+    - Unboxing of single argument constructors (verified)
+    - Implementation of "box" as a fixpoint expression (verified)
+    
+    *)
+Program Definition certirocq_post_metarocq_pipeline econf : Transform.t global_context global_context term term term term
+  (eval_eprogram final_wcbv_flags)
+  (eval_eprogram final_wcbv_flags) :=
+  let efl := EConstructorsAsBlocks.switch_cstr_as_blocks
+  (EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags)) in
+  let efl' := efl_coind_to_ind efl in
+  let efl'' := switch_off_thunk (efl_coind_to_ind efl) in
+  let efl''' := switch_off_box (switch_off_thunk (efl_coind_to_ind efl)) in
+  (* Rebuild the efficient lookup table *)
+  rebuild_wf_env_transform (efl := efl) false false ▷
+  (* Coinductives & cofixpoints are translated to inductive types and thunked fixpoints *)
+  coinductive_to_inductive_transformation efl
+      (has_app := eq_refl) (has_box := eq_refl) (has_rel := eq_refl) (has_pars := eq_refl) (has_cstrblocks := eq_refl) ▷
+  consts_to_values_transformation efl' final_wcbv_flags eq_refl eq_refl eq_refl ▷
+  (* Lazy-to-lambda *)
+  implement_lazy_force_transformation efl' eq_refl eq_refl eq_refl eq_refl eq_refl ▷
+  rebuild_wf_env_transform (efl := efl'') false false ▷
+  unbox_transformation efl'' final_wcbv_flags (has_app := _) (has_cofix := _) (has_prop_case := eq_refl) (has_letin := eq_refl) (has_cstrparams := eq_refl) (has_cstr_block := eq_refl) ▷
+  implement_box_transformation efl'' eq_refl eq_refl eq_refl eq_refl eq_refl ▷
+  ETransform.optional_self_transform econf.(enable_unsafe).(inductives_extraction)
+    (rebuild_wf_env_transform (efl := efl''') false false ▷
+       extract_inductive_transformation efl''' final_wcbv_flags econf.(extracted_inductives) ▷
+       forget_inductive_extraction_info_transformation efl''' final_wcbv_flags) ▷
+  (* Heuristically do it twice for more beta-normal terms *)
+  ETransform.optional_self_transform econf.(enable_unsafe).(Erasure.betared)
+    (betared_transformation efl''' final_wcbv_flags ▷
+     betared_transformation efl''' final_wcbv_flags).
+Next Obligation.
+Proof.
+  destruct econf as [[? ? [] ?] ? ? ? ? ?]; cbn in *; intuition eauto.
+Qed.
+Next Obligation.
+Proof.
+  destruct econf as [[? ? [] []] ? ? [] ? []]; cbn in *; intuition eauto.
+Qed.
+
+Program Definition run_erase_program {guard : PCUICWfEnvImpl.abstract_guard_impl} (econf : erasure_configuration)
+  (p : Transform.program inductives_mapping template_program) : pre pre_erasure_pipeline_mapping p -> Transform.program global_context EAst.term :=
+ if econf.(enable_typed_erasure) as _ return pre pre_erasure_pipeline_mapping p -> Transform.program global_context EAst.term then
+    run (typed_erasure_pipeline econf ▷ certirocq_post_metarocq_pipeline econf) p
+  else
+   run (erasure_pipeline_mapping econf ▷ certirocq_post_metarocq_pipeline econf) p.
+Next Obligation.
+Proof.
+  destruct econf as [[[] ? ? ?] ? ? [] ? ?]; cbn in *; intuition eauto.
+Qed.
+Next Obligation.
+Proof.
+  destruct econf as [[[] ? ? ?] ? ? [] ? []]; cbn in *; intuition eauto.
+Qed.

--- a/theories/Compiler/pipeline.v
+++ b/theories/Compiler/pipeline.v
@@ -12,7 +12,7 @@ Require Import MetaRocq.Common.BasicAst.
 From MetaRocq.Erasure Require Import EAst Erasure.
 From MetaRocq.ErasurePlugin Require Import Erasure.
 From MetaRocq.Utils Require Import MRString.
-
+From CertiRocq Require Import metarocq_pipeline.
 Import Monads.
 Import MonadNotation.
 Import ListNotations.
@@ -106,16 +106,14 @@ Definition next_id := 100%positive.
 Definition pipeline (p : Template.Ast.Env.program) :=
   let genv := fst p in
   '(prs, next_id) <- register_prims next_id genv.(Ast.Env.declarations) ;;
-(*   p <- erase_PCUIC p ;;
- *)  p <- CertiRocq_pipeline next_id prs false p ;;
+  p <- CertiRocq_pipeline next_id prs false p ;;
   compile_Clight prs p.
 
 Definition pipeline_Wasm (p : Template.Ast.Env.program) :=
   let genv := fst p in
   '(prs, next_id) <- register_prims next_id genv.(Ast.Env.declarations) ;;
-(*   p <- erase_PCUIC p ;;
- *)  p <- CertiRocq_pipeline next_id prs false p ;;
-     compile_LambdaANF_to_Wasm prs p.
+  p <- CertiRocq_pipeline next_id prs false p ;;
+  compile_LambdaANF_to_Wasm prs p.
 
 Definition default_opts : Options :=
   {| erasure_config := Erasure.default_erasure_config;

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -115,6 +115,7 @@ Glue/glue_utils.v
 Glue/glue.v
 
 # Compiler
+Compiler/metarocq_pipeline.v
 Compiler/pipeline.v
 
 # Extraction


### PR DESCRIPTION
Complete the MetaRocq pipeline used by CertiRocq and move to a separate file.

We now have verified every pass except cofix-to-fix (only relevant for cofix/coinductives), optional betared (requiring step-indexed logical relations) and of course the unverifiable, optional inductive remapping.