### PR TITLE
Remove box evaluation rule (EImplementBox runs before CertiRocq now)

### DIFF
--- a/theories/LambdaBox_to_LambdaANF/anf_correct.v
+++ b/theories/LambdaBox_to_LambdaANF/anf_correct.v
@@ -55,9 +55,6 @@ Section Correct.
     forall dc dc',
       dcon_to_tag default_tag dc tgm = dcon_to_tag default_tag dc' tgm -> dc = dc').
 
-  Context (box_dc : dcon)
-          (box_tag : dcon_to_tag default_tag box_dc tgm = default_tag).
-
   Context (cenv_case_consistent : forall P ctag,
     caseConsistent cenv P ctag).
 
@@ -181,7 +178,7 @@ Section Correct.
       decl.(EAst.cst_body) = Some body ->
       exists src_v f t,
         @eval_env_fuel _ LambdaBox_resource_fuel LambdaBox_resource_trace
-                       Σ box_dc [] body (fuel_sem.Val src_v) f t.
+                       Σ [] body (fuel_sem.Val src_v) f t.
 
   Definition globals_zero_fuel_prop :=
     (* Source constant unfolding is now semantic rather than hardcoded at fuel 0,
@@ -191,7 +188,7 @@ Section Correct.
       declared_constant Σ k decl ->
       decl.(EAst.cst_body) = Some body ->
       @eval_env_fuel _ LambdaBox_resource_fuel LambdaBox_resource_trace
-                     Σ box_dc [] body (fuel_sem.Val src_v) f t ->
+                     Σ [] body (fuel_sem.Val src_v) f t ->
       f = 0.
 
 
@@ -228,30 +225,30 @@ Section Correct.
   Let anf_cvt_rel_args' := anf_cvt_rel_args func_tag default_tag tgm cmap.
   Let anf_val_rel' :=
     @anf_val_rel func_tag default_tag tgm cmap nat
-                 LambdaBox_resource_fuel LambdaBox_resource_trace Σ box_dc.
+                 LambdaBox_resource_fuel LambdaBox_resource_trace Σ.
   Let anf_env_rel' :=
     @anf_env_rel func_tag default_tag tgm cmap nat
-                 LambdaBox_resource_fuel LambdaBox_resource_trace Σ box_dc.
+                 LambdaBox_resource_fuel LambdaBox_resource_trace Σ.
   Let global_env_rel' :=
     @global_env_rel func_tag default_tag tgm cmap nat
-                    LambdaBox_resource_fuel LambdaBox_resource_trace Σ box_dc.
+                    LambdaBox_resource_fuel LambdaBox_resource_trace Σ.
 
   (* Shorthand for the source evaluation relation.
      Must be explicit about both resource instances since both are
      [@LambdaBox_resource nat] and Coq's instance resolution can't
      distinguish them by type. *)
   Let src_eval := @eval_env_fuel nat LambdaBox_resource_fuel
-                                 LambdaBox_resource_trace Σ box_dc.
+                                 LambdaBox_resource_trace Σ.
   Let src_diverge := @fuel_sem.diverge nat LambdaBox_resource_fuel
-                                        LambdaBox_resource_trace Σ box_dc.
+                                        LambdaBox_resource_trace Σ.
   Let src_not_stuck := @fuel_sem.not_stuck nat LambdaBox_resource_fuel
-                                            LambdaBox_resource_trace Σ box_dc.
+                                            LambdaBox_resource_trace Σ.
   Let src_diverge_not_stuck := @fuel_sem.diverge_not_stuck nat LambdaBox_resource_fuel
-                                                          LambdaBox_resource_trace Σ box_dc.
+                                                          LambdaBox_resource_trace Σ.
 
   Context (Hcmap_eval_coherent :
     @cmap_eval_coherent cmap _ LambdaBox_resource_fuel
-                        LambdaBox_resource_trace Σ box_dc).
+                        LambdaBox_resource_trace Σ).
 
 
   (** ** Helpers *)
@@ -631,7 +628,7 @@ Section Correct.
   (* Extract individual evaluation from eval_fuel_many at position k. *)
   Lemma eval_fuel_many_nth rho es vs f t k e v :
     @eval_fuel_many _ LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc rho es vs f t ->
+                    Σ rho es vs f t ->
     nth_error es k = Some e ->
     nth_error vs k = Some v ->
     exists f_k t_k, src_eval rho e (fuel_sem.Val v) f_k t_k.
@@ -648,7 +645,7 @@ Section Correct.
 
   Lemma eval_fuel_many_length vs es vs1 f1 t1 :
     @eval_fuel_many _ LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc vs es vs1 f1 t1 ->
+                    Σ vs es vs1 f1 t1 ->
     Datatypes.length vs1 = Datatypes.length es.
   Proof.
     intros Hrel. induction Hrel.
@@ -1080,7 +1077,7 @@ Section Correct.
     src_eval rho0 e0 (fuel_sem.Val v0) f0 t0 ->
     well_formed_val Σ v0.
   Proof.
-    apply (wf.eval_preserves_wf _ _ Hglob_wf).
+    apply (wf.eval_preserves_wf _ Hglob_wf).
   Qed.
 
   (** Combined: eval preserves env_consistent when extending.
@@ -1103,7 +1100,7 @@ Section Correct.
   (** cmap_consistent shorthand — instantiates the definition from anf_util. *)
   Let cmap_consistent :=
     @anf_util.cmap_consistent cmap nat
-      LambdaBox_resource_fuel LambdaBox_resource_trace Σ box_dc.
+      LambdaBox_resource_fuel LambdaBox_resource_trace Σ.
 
   (** env_consistent extends when all duplicates of x1 map to v1 in rho.
       Same as old proof (trivial 4-line lemma). *)
@@ -1179,7 +1176,7 @@ Section Correct.
            exists f' t', src_eval [] body (fuel_sem.Val v) f' t')).
     intros rho e r f t Heval.
     eapply (@eval_env_fuel_ind'
-              nat LambdaBox_resource_fuel LambdaBox_resource_trace Σ box_dc
+              nat LambdaBox_resource_fuel LambdaBox_resource_trace Σ
               Pcombined
               (fun _ _ _ _ _ => True)
               Pcombined);
@@ -1243,21 +1240,7 @@ Section Correct.
         * match goal with
           | [ H : FromList _ \subset _ |- _ ] =>
             eapply H; eapply nth_error_In; eassumption
-          end.
-
-    - (* Box *)
-      intros ?
-             v Hv S0 vn0 S0' C0 x0 Hcvt Hdis Hdis_cm Hcons Hcmap.
-      injection Hv as <-.
-      remember EAst.tBox as e_box.
-      destruct Hcvt; try discriminate. clear Heqe_box.
-      split.
-      + intros i Hnth_i. exfalso. eapply Hdis. constructor.
-        * eapply nth_error_In. exact Hnth_i.
-        * assumption.
-      + intros k_f decl_f body_f Hlk_f _ _. exfalso. eapply Hdis_cm. constructor.
-        * exists k_f. exact Hlk_f.
-        * assumption.
+          end.    
 
     - (* App: x ∈ S3 ⊆ S2 ⊆ S, contradiction *)
       intros ? ? ? ? ? ? ? ? ? ? ? ? ? ?
@@ -1488,7 +1471,7 @@ Section Correct.
   (* Position tracking for args: if xs[j] = vn[i] = x, then vs[j] = rho[i]. *)
   Lemma anf_cvt_rel_args_var_lookup rho es vs f t :
     @eval_fuel_many _ LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc rho es vs f t ->
+                    Σ rho es vs f t ->
     forall S vn S' C xs,
       anf_cvt_rel_args' S es vn S' C xs ->
       Disjoint _ (FromList vn) S ->
@@ -2503,7 +2486,7 @@ Section Correct.
   Lemma anf_cvt_args_consistent k rho_src es vs_src f t
         S vn S' C xs vs_tgt (rho_tgt : M.t val) :
     @eval_fuel_many _ LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc rho_src es vs_src f t ->
+                    Σ rho_src es vs_src f t ->
     anf_cvt_rel_args' S es vn S' C xs ->
     Disjoint _ (FromList vn) S ->
     Disjoint _ (cmap_vars cmap) S ->
@@ -2538,7 +2521,7 @@ Section Correct.
                   _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                   eq_fuel_compat (fun _ _ H0 => H0)
                   nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                  Σ box_dc Hglob_term func_tag default_tag); eassumption.
+                  Σ Hglob_term func_tag default_tag); eassumption.
       + (* x ∉ FromList vn: use In_range to split S vs cmap *)
         destruct (anf_cvt_rel_args_In_range _ _ _ _ _ _ Hcvt x (nth_error_In _ _ Hxi))
           as [Hvn | [HS | Hcm]].
@@ -2605,7 +2588,7 @@ Section Correct.
                     _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                     eq_fuel_compat (fun _ _ H0 => H0)
                     nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc Hglob_term func_tag default_tag); eassumption.
+                    Σ Hglob_term func_tag default_tag); eassumption.
   Qed.
 
 
@@ -2892,7 +2875,7 @@ Section Correct.
           rewrite Henames. eapply nth_error_In. exact Hfn_idx. }
         (* Build anf_rel_ClosFix *)
         rewrite Hflen in Hfn_idx.
-        exact (@anf_rel_ClosFix _ _ _ _ _ _ _ _ _ S1 S2 names0 fnames0
+        exact (@anf_rel_ClosFix _ _ _ _ _ _ _ _ S1 S2 names0 fnames0
                   rho_s rho_t mfix Bs
                   (Datatypes.length mfix - 1 - k) fname
                   Henv Hcons Hcmap_c Hnd Hdis1 Hdis_cm Hdis_cm_fn Hdis_nf
@@ -3211,7 +3194,7 @@ Section Correct.
   Proof.
     intros vs e r f t Heval.
     eapply (@eval_env_fuel_ind'
-              nat LambdaBox_resource_fuel LambdaBox_resource_trace Σ box_dc
+              nat LambdaBox_resource_fuel LambdaBox_resource_trace Σ
               (fun vs e r f t => anf_cvt_correct_exp_step vs e r f t)
               (fun vs es vs1 f t => anf_cvt_correct_exps vs es vs1 f t)).
 
@@ -3247,7 +3230,7 @@ Section Correct.
                     _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                     eq_fuel_compat (fun _ _ H => H)
                     nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc Hglob_term func_tag default_tag);
+                    Σ Hglob_term func_tag default_tag);
             eassumption.
         * unfold preord_var_env. intros w Hget.
           rewrite M.gso in Hget; [| exact Hneq].
@@ -3273,7 +3256,7 @@ Section Correct.
                         _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                         eq_fuel_compat (fun _ _ H => H)
                         nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                        Σ box_dc Hglob_term func_tag default_tag).
+                        Σ Hglob_term func_tag default_tag).
               + eassumption.
               + eapply anf_rel_Clos
                   with (names := vnames) (S1 := S \\ [set x1] \\ [set x]);
@@ -3328,7 +3311,7 @@ Section Correct.
                         _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                         eq_fuel_compat (fun _ _ H => H)
                         nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                        Σ box_dc Hglob_term func_tag default_tag).
+                        Σ Hglob_term func_tag default_tag).
               + eassumption.
               + eapply anf_rel_ClosFix
                   with (names := vnames) (S1 := S \\ FromList fnames);
@@ -3360,34 +3343,6 @@ Section Correct.
                   apply Hsub_mfix in Hin_S'. destruct Hin_S' as [_ Habs].
                   apply Habs. exact Hc.
                 - intro Habs. inv Habs. contradiction. }
-              eapply preord_val_refl. tci. }
-        unfold inclusion, comp, eq_fuel, one_step, anf_bound.
-        intros [[[? ?] ?] ?] [[[? ?] ?] ?] [[[[? ?] ?] ?] [? ?]].
-        unfold_all. cbn in *. lia.
-
-    (* eval_Box_fuel *)
-    - intros rho0.
-      unfold anf_cvt_correct_exp_step.
-      intros rho vnames C x S S' i Hwf Hwfe Hcons Hcmap Hdis Hdis_cmap Henv Hglob Hrel e_k Hdis_ek.
-      inv Hrel.
-      intros v0 v' Heq Hvrel. injection Heq as <-.
-        eapply preord_exp_post_monotonic.
-        2:{ eapply preord_exp_trans; [tci | exact eq_fuel_idemp | | ].
-            2:{ intros m. eapply preord_exp_Econstr_red.
-                simpl. reflexivity. }
-            eapply preord_exp_refl. now eapply eq_fuel_compat.
-            intros y Hy.
-            destruct (Pos.eq_dec y x) as [Heq | Hneq].
-            - subst. intros v1 Hget. rewrite M.gss in Hget. inv Hget.
-              eexists. split. rewrite M.gss. reflexivity.
-              inv Hvrel.
-              match goal with
-              | [ H : Forall2 _ [] ?vs |- _ ] => inv H
-              end.
-              rewrite preord_val_eq. simpl. split; [| constructor].
-              exact box_tag.
-            - intros v1 Hget. rewrite M.gso in Hget; eauto.
-              eexists. split. rewrite M.gso; eauto.
               eapply preord_val_refl. tci. }
         unfold inclusion, comp, eq_fuel, one_step, anf_bound.
         intros [[[? ?] ?] ?] [[[? ?] ?] ?] [[[[? ?] ?] ?] [? ?]].
@@ -3724,7 +3679,7 @@ Section Correct.
                     _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                     eq_fuel_compat (fun _ _ H => H)
                     nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc Hglob_term func_tag default_tag).
+                    Σ Hglob_term func_tag default_tag).
                   exact Hrel_clos_saved.
                   exact Hrel_rho.
                 - intros m0.
@@ -3732,7 +3687,7 @@ Section Correct.
                     _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                     eq_fuel_compat (fun _ _ H => H)
                     nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc Hglob_term func_tag default_tag).
+                    Σ Hglob_term func_tag default_tag).
                   rewrite Heq_v2 in Hrel_rho. exact Hrel_rho.
                   exact Hrel_v2. }
               (* Step 4: extract Vfun structure of v2' from preord_val *)
@@ -3843,7 +3798,7 @@ Section Correct.
                       _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                       eq_fuel_compat (fun _ _ H => H)
                       nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                      Σ box_dc Hglob_term func_tag default_tag).
+                      Σ Hglob_term func_tag default_tag).
                     * assert (v0 = v_rho) by congruence. subst v0.
                       exact Hrel_rho_v2.
                     * exact Hrel_v2.
@@ -3916,7 +3871,7 @@ Section Correct.
                               _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                               eq_fuel_compat (fun _ _ H => H)
                               nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                              Σ box_dc Hglob_term func_tag default_tag);
+                              Σ Hglob_term func_tag default_tag);
                       [exact Hrel_k0 | exact Hrel_v2].
                   * (* x2 ∈ S2: contradiction via Hdis_ek *)
                     exfalso.
@@ -3956,7 +3911,7 @@ Section Correct.
                                  _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                  eq_fuel_compat (fun _ _ H => H)
                                  nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                 Σ box_dc Hglob_term func_tag default_tag);
+                                 Σ Hglob_term func_tag default_tag);
                          [exact Hrel_k0' | exact Hrel_v2].
                     -- (* x2 not in FromList: use global_env_rel' *)
                        eexists. split.
@@ -3986,7 +3941,7 @@ Section Correct.
                                  _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                  eq_fuel_compat (fun _ _ H => H)
                                  nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                 Σ box_dc Hglob_term func_tag default_tag);
+                                 Σ Hglob_term func_tag default_tag);
                          [exact (Hrel_c v2 f_c t_c Heval2_c) | exact Hrel_v2].
                 + destruct (Pos.eq_dec y x1) as [-> | Hneq_x1].
                   * (* y = x1 *)
@@ -4011,7 +3966,7 @@ Section Correct.
                                  _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                  eq_fuel_compat (fun _ _ H => H)
                                  nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                 Σ box_dc Hglob_term func_tag default_tag);
+                                 Σ Hglob_term func_tag default_tag);
                          [exact Hrel_k1 | exact Hrel_clos_saved].
                     -- (* x1 ∈ S: contradiction via Hdis_ek *)
                        exfalso.
@@ -4048,7 +4003,7 @@ Section Correct.
                                     _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                     eq_fuel_compat (fun _ _ H => H)
                                     nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                    Σ box_dc Hglob_term func_tag default_tag);
+                                    Σ Hglob_term func_tag default_tag);
                             [exact Hrel_k1' | exact Hrel_clos_saved].
                        ++ (* x1 not in FromList: use global_env_rel' *)
                           eexists. split.
@@ -4073,7 +4028,7 @@ Section Correct.
                                     _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                     eq_fuel_compat (fun _ _ H => H)
                                     nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                 Σ box_dc Hglob_term func_tag default_tag);
+                                 Σ Hglob_term func_tag default_tag);
                          [exact (Hrel_c1 (Clos_v rho' na0 body0) f_c1 t_c1 Heval1_c1) | exact Hrel_clos_saved].
                   * (* y ≠ x, ≠ x1, ≠ x2 *)
                     eexists. split.
@@ -4447,14 +4402,14 @@ Section Correct.
                     _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                     eq_fuel_compat (fun _ _ HH => HH)
                     nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc Hglob_term func_tag default_tag).
+                    Σ Hglob_term func_tag default_tag).
                   exact Hrel_fix_saved. exact Hrel_rho.
                 - intros m0.
                   eapply (@anf_cvt_val_alpha_equiv
                     _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                     eq_fuel_compat (fun _ _ HH => HH)
                     nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc Hglob_term func_tag default_tag).
+                    Σ Hglob_term func_tag default_tag).
                   rewrite Heq_v2 in Hrel_rho. exact Hrel_rho. exact Hrel_v2. }
               (* Step 3: extract Vfun from v2' *)
               assert (Hpv_inst := Hpv_cv (cin_bc + i + 1)%nat).
@@ -4553,7 +4508,7 @@ Section Correct.
                       _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                       eq_fuel_compat (fun _ _ HH => HH)
                       nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                      Σ box_dc Hglob_term func_tag default_tag).
+                      Σ Hglob_term func_tag default_tag).
                     * assert (w = v_rho) by congruence. subst w.
                       exact Hrel_rho_v2.
                     * exact Hrel_v2.
@@ -4616,7 +4571,7 @@ Section Correct.
                                 _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                 eq_fuel_compat (fun _ _ HH => HH)
                                 nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                Σ box_dc Hglob_term func_tag default_tag);
+                                Σ Hglob_term func_tag default_tag);
                         [exact Hrel_k0 | exact Hrel_v2].
                     * (* x2 ∈ S2: contradiction *)
                       exfalso.
@@ -4652,7 +4607,7 @@ Section Correct.
                                    _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                    eq_fuel_compat (fun _ _ HH => HH)
                                    nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                   Σ box_dc Hglob_term func_tag default_tag);
+                                   Σ Hglob_term func_tag default_tag);
                            [exact Hrel_k0' | exact Hrel_v2].
                       -- eexists. split.
                          { rewrite M.gso; [rewrite M.gss; reflexivity | exact Hneq_x]. }
@@ -4679,7 +4634,7 @@ Section Correct.
                                    _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                    eq_fuel_compat (fun _ _ HH => HH)
                                    nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                   Σ box_dc Hglob_term func_tag default_tag);
+                                   Σ Hglob_term func_tag default_tag);
                            [exact (Hrel_c v2 f_c' t_c' Heval2_c) | exact Hrel_v2].
                   + destruct (Pos.eq_dec y x1) as [-> | Hneq_x1].
                     * (* y = x1: same as App but with ClosFix_v *)
@@ -4702,7 +4657,7 @@ Section Correct.
                                    _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                    eq_fuel_compat (fun _ _ HH => HH)
                                    nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                   Σ box_dc Hglob_term func_tag default_tag);
+                                   Σ Hglob_term func_tag default_tag);
                            [exact Hrel_k1 | exact Hrel_fix_saved].
                       -- (* x1 ∈ S: contradiction *)
                          exfalso.
@@ -4735,7 +4690,7 @@ Section Correct.
                                       _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                       eq_fuel_compat (fun _ _ HH => HH)
                                       nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                      Σ box_dc Hglob_term func_tag default_tag);
+                                      Σ Hglob_term func_tag default_tag);
                               [exact Hrel_k1' | exact Hrel_fix_saved].
                          ++ eexists. split.
                             { rewrite M.gso; [| exact Hneq_x].
@@ -4759,7 +4714,7 @@ Section Correct.
                                       _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                                       eq_fuel_compat (fun _ _ HH => HH)
                                       nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                                      Σ box_dc Hglob_term func_tag default_tag);
+                                      Σ Hglob_term func_tag default_tag);
                               [exact (Hrel_c1 _ _ _ Heval1_c1) | exact Hrel_fix_saved].
                     * (* y ≠ x, ≠ x1, ≠ x2 *)
                       eexists. split.
@@ -5001,7 +4956,7 @@ Section Correct.
                            _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                            eq_fuel_compat (fun _ _ H => H)
                            nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                           Σ box_dc Hglob_term func_tag default_tag);
+                           Σ Hglob_term func_tag default_tag);
                    [exact Hrel_w | exact Hrel1].
               -- (* y ≠ x1 *)
                  eexists. split.
@@ -5154,7 +5109,7 @@ Section Correct.
                      _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                      eq_fuel_compat (fun _ _ H0 => H0)
                      nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                     Σ box_dc Hglob_term func_tag default_tag); eassumption.
+                     Σ Hglob_term func_tag default_tag); eassumption.
                 ++ (* y ∈ S \ {x} (fresh): contradiction with Hdis_ek *)
                    exfalso.
                    assert (Hy_not_S' : ~ y \in S').
@@ -5193,7 +5148,7 @@ Section Correct.
                         _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                         eq_fuel_compat (fun _ _ H0 => H0)
                         nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                        Σ box_dc Hglob_term func_tag default_tag); eassumption.
+                        Σ Hglob_term func_tag default_tag); eassumption.
                    ** (* y ∉ FromList vnames: cmap approach *)
                       destruct (In_nth_error _ _ Hyin) as [k Hk].
                       destruct (first_occurrence_exists xs k y Hk) as [k0 [Hle [Hk0 Hfirst]]].
@@ -5257,7 +5212,7 @@ Section Correct.
                         _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                         eq_fuel_compat (fun _ _ H0 => H0)
                         nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                        Σ box_dc Hglob_term func_tag default_tag).
+                        Σ Hglob_term func_tag default_tag).
                       { eapply Hrel_glob. exact Heval_body_k0. }
                       { exact Hrel_vy. }
               -- (* y ∉ xs: set_many doesn't affect y *)
@@ -5719,7 +5674,7 @@ Section Correct.
                    _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                    eq_fuel_compat (fun _ _ H0 => H0)
                    nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                   Σ box_dc Hglob_term func_tag default_tag).
+                   Σ Hglob_term func_tag default_tag).
                  exact Hrel_vz.
                  exact Hcon_rel.
               -- (* z ≠ x1 *)
@@ -5898,7 +5853,7 @@ Section Correct.
                         _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                         eq_fuel_compat (fun _ _ H => H)
                         nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                        Σ box_dc Hglob_term func_tag default_tag);
+                        Σ Hglob_term func_tag default_tag);
                 [exact Hrel' | exact Hrel_proj].
             * destruct (Pos.eq_dec z x) as [-> | Hneq_zx].
               -- (* z = x: M.get x rho ≈ v_con' *)
@@ -5973,7 +5928,7 @@ Section Correct.
                            _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                            eq_fuel_compat (fun _ _ H => H)
                            nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                           Σ box_dc Hglob_term func_tag default_tag);
+                           Σ Hglob_term func_tag default_tag);
                    [exact Hrel_w0 | exact Hrel_con_saved].
               -- (* z ≠ x_res, z ≠ x *)
                  unfold preord_var_env. intros w Hget.
@@ -6047,7 +6002,7 @@ Section Correct.
                     _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                     eq_fuel_compat (fun _ _ H => H)
                     nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                    Σ box_dc Hglob_term func_tag default_tag);
+                    Σ Hglob_term func_tag default_tag);
             [exact Hrel1 | exact Hav_rel].
         * (* z ≠ x *)
           unfold preord_var_env. intros w Hget.
@@ -6416,7 +6371,7 @@ Section Correct.
                          _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                          eq_fuel_compat (fun _ _ H => H)
                          nat LambdaBox_resource_fuel LambdaBox_resource_trace
-                         Σ box_dc Hglob_term func_tag default_tag);
+                         Σ Hglob_term func_tag default_tag);
                  [exact H1 | exact Hrel_j].
             -- (* x1 ∉ xs0 *)
                eexists. split.

--- a/theories/LambdaBox_to_LambdaANF/anf_corresp.v
+++ b/theories/LambdaBox_to_LambdaANF/anf_corresp.v
@@ -1181,7 +1181,7 @@ Section ValRelExists.
           {Hf_src : @LambdaBox_resource nat}
           {Ht_src : @LambdaBox_resource src_trace}.
 
-  Context (Hglob_term : globals_terminate Σ box_dc).
+  Context (Hglob_term : globals_terminate Σ).
   Context (Hwf_glob : EWellformed.wf_glob Σ).
 
   (* Pipeline flags needed for anf_rel_exists *)
@@ -1201,9 +1201,9 @@ Section ValRelExists.
       declared_constant Σ k decl /\ decl.(EAst.cst_body) = Some body).
   Context (cmap_nodup_keys : NoDup (map fst cmap)).
   Context (Hcmap_eval_coherent :
-    @cmap_eval_coherent cmap _ Hf_src Ht_src Σ box_dc).
+    @cmap_eval_coherent cmap _ Hf_src Ht_src Σ).
 
-  Let anf_val_rel' := anf_val_rel func_tag default_tag tgm cmap Σ box_dc.
+  Let anf_val_rel' := anf_val_rel func_tag default_tag tgm cmap Σ.
 
   (* Convert anf_cvt_rel_mfix to anf_fix_rel.
      Proved here since anf_correct.v (which has this lemma) imports anf_corresp.v. *)
@@ -1301,7 +1301,7 @@ Section ValRelExists.
   Lemma anf_val_rel_clos_exists vs vs' na e rho_g :
     Forall2 anf_val_rel' vs vs' ->
     wellformed Σ (S (List.length vs)) e = true ->
-    global_env_rel func_tag default_tag tgm cmap Σ box_dc (kn_deps e) rho_g ->
+    global_env_rel func_tag default_tag tgm cmap Σ (kn_deps e) rho_g ->
     exists v', anf_val_rel' (Clos_v vs na e) v'.
   Proof.
     intros Hvs' Hwf_e Hglob_rel.
@@ -1403,7 +1403,7 @@ Section ValRelExists.
     Forall (fun d =>
       EAst.isLambda (EAst.dbody d) = true /\
       wellformed Σ (List.length mfix + List.length vs) (EAst.dbody d) = true) mfix ->
-    global_env_rel func_tag default_tag tgm cmap Σ box_dc (kn_deps_mfix mfix) rho_g ->
+    global_env_rel func_tag default_tag tgm cmap Σ (kn_deps_mfix mfix) rho_g ->
     exists v', anf_val_rel' (ClosFix_v vs mfix n) v'.
   Proof.
     intros Hvs' Hn_lt Hwf_mfix Hglob_rel.
@@ -1635,7 +1635,7 @@ Section ValRelExists.
         destruct Hvs' as [vs' Hvs'].
         (* Build global target env using wf_glob IH *)
         assert (Hglob : exists rho_g,
-          global_env_rel func_tag default_tag tgm cmap Σ box_dc
+          global_env_rel func_tag default_tag tgm cmap Σ
             (kn_deps e) rho_g).
         { (* Build rho_g by iterating over cmap.
              For each (k0, v0) in cmap: if k0 is declared in Σ0 with body,
@@ -1651,7 +1651,7 @@ Section ValRelExists.
               EAst.cst_body decl = Some body /\
               M.get v_g rho_g = Some anf_v /\
               (forall src_v f0 t0,
-                eval_env_fuel Σ box_dc [] body (Val src_v) f0 t0 ->
+                eval_env_fuel Σ [] body (Val src_v) f0 t0 ->
                 anf_val_rel' src_v anf_v)).
           { induction cm as [| [k0 v0] cm' IHcm]; intros Hcm_nodup Hcm_sub.
             - (* cm = [] *) exists (M.empty val). intros. discriminate.
@@ -1788,7 +1788,7 @@ Section ValRelExists.
         destruct Hvs' as [vs' Hvs'].
         (* Build global target env — same iteration as Clos_v *)
         assert (Hglob : exists rho_g,
-          global_env_rel func_tag default_tag tgm cmap Σ box_dc
+          global_env_rel func_tag default_tag tgm cmap Σ
             (kn_deps_mfix mfix) rho_g).
         { unfold global_env_rel, global_env_rel'.
           assert (Hbuild : forall cm,
@@ -1801,7 +1801,7 @@ Section ValRelExists.
               EAst.cst_body decl = Some body /\
               M.get v_g rho_g = Some anf_v /\
               (forall src_v f0 t0,
-                eval_env_fuel Σ box_dc [] body (Val src_v) f0 t0 ->
+                eval_env_fuel Σ [] body (Val src_v) f0 t0 ->
                 anf_val_rel' src_v anf_v)).
           { induction cm as [| [k0 v0] cm' IHcm]; intros Hcm_nodup Hcm_sub.
             - exists (M.empty val). intros. discriminate.

--- a/theories/LambdaBox_to_LambdaANF/anf_divergence.v
+++ b/theories/LambdaBox_to_LambdaANF/anf_divergence.v
@@ -41,20 +41,18 @@ Section Divergence.
     forall dc dc',
       dcon_to_tag default_tag dc tgm = dcon_to_tag default_tag dc' tgm -> dc = dc').
 
-  Context (box_dc : dcon)
-          (box_tag : dcon_to_tag default_tag box_dc tgm = default_tag).
 
   Context (cenv_case_consistent : forall P ctag,
     caseConsistent cenv P ctag).
 
   Context (Hcmap_eval_coherent :
     @cmap_eval_coherent cmap nat
-                        (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-                        (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-                        Σ box_dc).
+                        (LambdaBox_resource_fuel)
+                        (LambdaBox_resource_trace)
+                        Σ).
 
-  Context (Hglob_term : globals_terminate_prop default_tag tgm Σ box_dc box_tag).
-  Context (Hglob_fuel_zero : globals_zero_fuel_prop default_tag tgm Σ box_dc box_tag).
+  Context (Hglob_term : globals_terminate_prop Σ).
+  Context (Hglob_fuel_zero : globals_zero_fuel_prop Σ).
 
   Context (Hglob_wf : forall k decl body,
     declared_constant Σ k decl ->
@@ -67,59 +65,59 @@ Section Divergence.
       exists v',
         @anf_val_rel func_tag default_tag tgm cmap
                      nat
-                     (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-                     (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-                     Σ box_dc v v').
+                     (LambdaBox_resource_fuel)
+                     (LambdaBox_resource_trace)
+                     Σ v v').
 
   Let anf_cvt_rel' := anf_cvt_rel func_tag default_tag tgm cmap.
   Let anf_cvt_rel_args' := anf_cvt_rel_args func_tag default_tag tgm cmap.
   Let cmap_consistent' :=
     @cmap_consistent cmap nat
-                     (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-                     (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-                     Σ box_dc.
+                     (LambdaBox_resource_fuel)
+                     (LambdaBox_resource_trace)
+                     Σ.
   Let anf_val_rel' :=
     @anf_val_rel func_tag default_tag tgm cmap
                  nat
-                 (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-                 (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-                 Σ box_dc.
+                 (LambdaBox_resource_fuel)
+                 (LambdaBox_resource_trace)
+                 Σ.
   Let anf_env_rel' :=
     @anf_env_rel func_tag default_tag tgm cmap
                  nat
-                 (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-                 (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-                 Σ box_dc.
+                 (LambdaBox_resource_fuel)
+                 (LambdaBox_resource_trace)
+                 Σ.
   Let global_env_rel' :=
     @global_env_rel func_tag default_tag tgm cmap
                     nat
-                    (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-                    (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-                    Σ box_dc.
+                    (LambdaBox_resource_fuel)
+                    (LambdaBox_resource_trace)
+                    Σ.
   Let src_eval :=
     @eval_env_fuel nat
-                   (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-                   (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-                   Σ box_dc.
+                   (LambdaBox_resource_fuel)
+                   (LambdaBox_resource_trace)
+                   Σ.
   Let src_fuel_res : @LambdaBox_resource nat :=
-    LambdaBox_resource_fuel default_tag tgm box_dc box_tag.
+    LambdaBox_resource_fuel.
   #[local] Existing Instance src_fuel_res.
   Let src_trace_res : @LambdaBox_resource nat :=
-    LambdaBox_resource_trace default_tag tgm box_dc box_tag.
+    LambdaBox_resource_trace.
   Let src_one :=
     @one_i EAst.term nat (@HRes _ src_fuel_res).
   Let src_diverge :=
     @fuel_sem.diverge nat
-                      (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-                      (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-                      Σ box_dc.
+                      (LambdaBox_resource_fuel)
+                      (LambdaBox_resource_trace)
+                      Σ.
   Let src_not_stuck :=
     @fuel_sem.not_stuck nat
-                        (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-                        (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-                        Σ box_dc.
+                        (LambdaBox_resource_fuel)
+                        (LambdaBox_resource_trace)
+                        Σ.
   Let eq_fuel_compat' :=
-    @eq_fuel_compat func_tag default_tag tgm cmap cenv Σ box_dc box_tag.
+    @eq_fuel_compat func_tag default_tag tgm cmap cenv Σ.
 
   Definition anf_cvt_correct_exps'
              (vs_env : fuel_sem.env) (es : list EAst.term)
@@ -160,7 +158,7 @@ Section Divergence.
       | fuel_sem.Val _ =>
         forall f_oot t_oot,
           @eval_env_step _ src_fuel_res src_trace_res
-                         Σ box_dc rho e fuel_sem.OOT f_oot t_oot ->
+                         Σ rho e fuel_sem.OOT f_oot t_oot ->
           f_oot < f
       | fuel_sem.OOT => True
       end).
@@ -169,7 +167,7 @@ Section Divergence.
       forall args_done e args_rest vs_done fs' f_oot t_oot ts',
         es = args_done ++ e :: args_rest ->
         @eval_fuel_many _ src_fuel_res src_trace_res
-                        Σ box_dc rho args_done vs_done fs' ts' ->
+                        Σ rho args_done vs_done fs' ts' ->
         src_eval rho e fuel_sem.OOT f_oot t_oot ->
         fs' + f_oot < fs).
     set (Pfuel := fun (rho : fuel_sem.env) (e : EAst.term)
@@ -184,7 +182,7 @@ Section Divergence.
     enough (Haux : Pfuel rho0 e0 (fuel_sem.Val v0) f_val t_val) by exact Haux.
     eapply (@eval_env_fuel_ind'
               nat src_fuel_res src_trace_res
-              Σ box_dc Pstep Pmany Pfuel); try exact Hval;
+              Σ Pstep Pmany Pfuel); try exact Hval;
       unfold Pstep, Pmany, Pfuel; simpl in *.
     - intros n rho v Hnth f_oot t_oot Hoot.
       remember (EAst.tRel n) as e_rel in Hoot.
@@ -196,10 +194,6 @@ Section Divergence.
       destruct Hoot; try discriminate.
     - intros mfix idx rho f_oot t_oot Hoot.
       remember (EAst.tFix mfix idx) as e_fix in Hoot.
-      remember fuel_sem.OOT as r_oot in Hoot.
-      destruct Hoot; try discriminate.
-    - intros rho f_oot t_oot Hoot.
-      remember EAst.tBox as e_box in Hoot.
       remember fuel_sem.OOT as r_oot in Hoot.
       destruct Hoot; try discriminate.
     - intros e1 e2 body v2 r na rho rho' f1 f2 f3 t1 t2 t3
@@ -514,7 +508,7 @@ Section Divergence.
                       (r : fuel_sem.result) (f : nat) (t : nat) =>
       forall f', f' < f ->
       exists t', @eval_env_step _ src_fuel_res src_trace_res
-                                 Σ box_dc rho e fuel_sem.OOT f' t').
+                                 Σ rho e fuel_sem.OOT f' t').
     set (Pmany := fun (rho : fuel_sem.env) (es : list EAst.term)
                       (vs : list fuel_sem.value) (fs : nat) (ts : nat) =>
       forall f',
@@ -522,7 +516,7 @@ Section Divergence.
         exists args_done e args_rest vs_done fs' f_oot t_oot ts',
           es = args_done ++ e :: args_rest /\
           @eval_fuel_many _ src_fuel_res src_trace_res
-                          Σ box_dc rho args_done vs_done fs' ts' /\
+                          Σ rho args_done vs_done fs' ts' /\
           src_eval rho e fuel_sem.OOT f_oot t_oot /\
           f' = fs' + f_oot).
     set (Pfuel := fun (rho : fuel_sem.env) (e : EAst.term)
@@ -532,13 +526,12 @@ Section Divergence.
     enough (Haux : Pfuel rho0 e0 r0 f0 t0) by exact Haux.
     eapply (@eval_env_fuel_ind'
               nat src_fuel_res src_trace_res
-              Σ box_dc Pstep Pmany Pfuel); try exact Heval;
+              Σ Pstep Pmany Pfuel); try exact Heval;
       unfold Pstep, Pmany, Pfuel;
       simpl in *.
     - intros n rho v Hnth f' Hlt. exfalso. lia.
     - intros body rho na f' Hlt. exfalso. lia.
     - intros mfix idx rho f' Hlt. exfalso. lia.
-    - intros rho f' Hlt. exfalso. lia.
     - intros e1 e2 body v2 r na rho rho' f1 f2 f3 t1 t2 t3
              He1 IH1 He2 IH2 Hbody IH3 f' Hlt.
       destruct (Nat.lt_ge_cases f' f1) as [Hlt1 | Hge1].
@@ -552,7 +545,7 @@ Section Divergence.
           rewrite Heqf.
           exact (@fuel_sem.eval_App_step_OOT2
                    nat src_fuel_res src_trace_res
-                   Σ box_dc e1 e2 (fuel_sem.Clos_v rho' na body) rho
+                   Σ e1 e2 (fuel_sem.Clos_v rho' na body) rho
                    f1 (f' - f1) t1 t_oot He1 Hoot).
         * assert (Hlt3 : f' - f1 - f2 < f3) by lia.
           destruct (IH3 _ Hlt3) as [t_oot Hoot].
@@ -561,7 +554,7 @@ Section Divergence.
           rewrite Heqf.
           exact (@fuel_sem.eval_App_step
                    nat src_fuel_res src_trace_res
-                   Σ box_dc e1 e2 body v2 fuel_sem.OOT na rho rho'
+                   Σ e1 e2 body v2 fuel_sem.OOT na rho rho'
                    f1 f2 (f' - f1 - f2) t1 t2 t_oot
                    He1 He2 Hoot).
     - intros e1 e2 rho f1 t1 He1 IH1 f' Hlt.
@@ -578,7 +571,7 @@ Section Divergence.
         rewrite Heqf.
         exact (@fuel_sem.eval_App_step_OOT2
                  nat src_fuel_res src_trace_res
-                 Σ box_dc e1 e2 v rho f1 (f' - f1) t1 t_oot He1 Hoot).
+                 Σ e1 e2 v rho f1 (f' - f1) t1 t_oot He1 Hoot).
     - intros e1 e2 body rho rho' rho'' idx na mfix v2 r f1 f2 f3 t1 t2 t3
              He1 IH1 Hfix Hrec He2 IH2 Hbody IH3 f' Hlt.
       destruct (Nat.lt_ge_cases f' f1) as [Hlt1 | Hge1].
@@ -592,7 +585,7 @@ Section Divergence.
           rewrite Heqf.
           exact (@fuel_sem.eval_App_step_OOT2
                    nat src_fuel_res src_trace_res
-                   Σ box_dc e1 e2 (fuel_sem.ClosFix_v rho' mfix idx) rho
+                   Σ e1 e2 (fuel_sem.ClosFix_v rho' mfix idx) rho
                    f1 (f' - f1) t1 t_oot He1 Hoot).
         * assert (Hlt3 : f' - f1 - f2 < f3) by lia.
           destruct (IH3 _ Hlt3) as [t_oot Hoot].
@@ -601,7 +594,7 @@ Section Divergence.
           rewrite Heqf.
           exact (@fuel_sem.eval_FixApp_step
                    nat src_fuel_res src_trace_res
-                   Σ box_dc e1 e2 body rho rho' rho'' idx na mfix v2
+                   Σ e1 e2 body rho rho' rho'' idx na mfix v2
                    fuel_sem.OOT f1 f2 (f' - f1 - f2) t1 t2 t_oot
                    He1 Hfix Hrec He2 Hoot).
     - intros na b t v1 r rho f1 f2 t1 t2
@@ -616,7 +609,7 @@ Section Divergence.
         rewrite Heqf.
         exact (@fuel_sem.eval_LetIn_step
                  nat src_fuel_res src_trace_res
-                 Σ box_dc na b t v1 fuel_sem.OOT rho f1 (f' - f1) t1 t_oot
+                 Σ na b t v1 fuel_sem.OOT rho f1 (f' - f1) t1 t_oot
                  Heb Hoot).
     - intros na b t rho f1 t1 Heb IHb f' Hlt.
       destruct (IHb _ Hlt) as [t_oot Hoot].
@@ -629,7 +622,7 @@ Section Divergence.
       exists (ts' + t_oot).
       exact (@fuel_sem.eval_Construct_step_OOT
                nat src_fuel_res src_trace_res
-               Σ box_dc ind c (args_done ++ e :: args_rest)
+               Σ ind c (args_done ++ e :: args_rest)
                args_done args_rest e vs_done rho fs' f_oot t_oot ts'
                eq_refl Hmany_done Hoot).
     - intros ind c args args_done args_rest e vs rho fs f t ts
@@ -645,7 +638,7 @@ Section Divergence.
         rewrite Hfuel.
         exact (@fuel_sem.eval_Construct_step_OOT
                  nat src_fuel_res src_trace_res
-                 Σ box_dc ind c args
+                 Σ ind c args
                  args_done' (args_rest' ++ e :: args_rest) e'
                  vs_done rho fs' f_oot t_oot ts'
                  Hargs_total Hmany_done Hoot').
@@ -656,7 +649,7 @@ Section Divergence.
         rewrite Heqf.
         exact (@fuel_sem.eval_Construct_step_OOT
                  nat src_fuel_res src_trace_res
-                 Σ box_dc ind c args
+                 Σ ind c args
                  args_done args_rest e vs rho fs (f' - fs) t_oot' ts
                  Hargs Hdone Hoot').
     - intros ind npars mch brs rho dc vs body c r f1 f2 t1 t2
@@ -671,7 +664,7 @@ Section Divergence.
         rewrite Heqf.
         exact (@fuel_sem.eval_Case_step
                  nat src_fuel_res src_trace_res
-                 Σ box_dc ind npars mch brs rho dc vs body c fuel_sem.OOT
+                 Σ ind npars mch brs rho dc vs body c fuel_sem.OOT
                  f1 (f' - f1) t1 t_oot
                  Hmch Hdc Hfind Hoot).
     - intros ind npars mch brs rho f1 t1 Hmch IHmch f' Hlt.
@@ -710,7 +703,7 @@ Section Divergence.
         * split.
           -- exact (@fuel_sem.eval_many_cons
                       nat src_fuel_res src_trace_res
-                      Σ box_dc rho e args_done v vs_done f fs' t ts'
+                      Σ rho e args_done v vs_done f fs' t ts'
                       He Hmany_done).
           -- split.
              ++ exact Hoot.
@@ -720,13 +713,13 @@ Section Divergence.
       assert (Hlt0' : (f' < fuel_exp e)%nat) by lia.
       exact (@fuel_sem.eval_OOT
                nat src_fuel_res src_trace_res
-               Σ box_dc rho e f' Hlt0').
+               Σ rho e f' Hlt0').
     - intros rho e r f t Hstep IHstep f' Hlt.
       destruct (Nat.lt_ge_cases f' (fuel_exp e)) as [Hlt0 | Hge0].
       + exists 0%nat.
         exact (@fuel_sem.eval_OOT
                  nat src_fuel_res src_trace_res
-                 Σ box_dc rho e f' Hlt0).
+                 Σ rho e f' Hlt0).
       + assert (Hlt_step : f' - fuel_exp e < f) by lia.
         destruct (IHstep _ Hlt_step) as [t_oot Hoot].
         exists (t_oot + anf_trace_exp e).
@@ -734,7 +727,7 @@ Section Divergence.
         rewrite Heqf.
         exact (@fuel_sem.eval_step
                  nat src_fuel_res src_trace_res
-                 Σ box_dc rho e fuel_sem.OOT (f' - fuel_exp e) t_oot Hoot).
+                 Σ rho e fuel_sem.OOT (f' - fuel_exp e) t_oot Hoot).
   Qed.
 
   Lemma src_eval_lt_OOT rho e v f t f' :
@@ -810,7 +803,7 @@ Section Divergence.
         destruct Happ_val as [src_v [f_app [t_app Happ_val]]].
         destruct (@fuel_sem.src_eval_app_val_body
                     nat src_fuel_res src_trace_res
-                    Σ box_dc rho e1 e2 rho' na body v2 src_v
+                    Σ rho e1 e2 rho' na body v2 src_v
                     f1 t1 f2 t2 f_app t_app He1 He2 Happ_val)
           as [f3 [t3 Hbody_val]].
         apply Hnoval. eexists _, _, _. exact Hbody_val.
@@ -888,7 +881,7 @@ Section Divergence.
         destruct Happ_val as [src_v [f_app [t_app Happ_val]]].
         destruct (@fuel_sem.src_eval_fixapp_val_body
                     nat src_fuel_res src_trace_res
-                    Σ box_dc rho e1 e2 rho' idx na mfix body v2 src_v
+                    Σ rho e1 e2 rho' idx na mfix body v2 src_v
                     f1 t1 f2 t2 f_app t_app He1 Hfix He2 Happ_val)
           as [f3 [t3 Hbody_val]].
         rewrite Hrec in Hbody_val.
@@ -919,7 +912,7 @@ Section Divergence.
     inversion Hoot_case; subst.
     - simpl in H. lia.
     - match goal with
-      | [ Hstep : @eval_env_step _ _ _ Σ box_dc rho
+      | [ Hstep : @eval_env_step _ _ _ Σ rho
                      (EAst.tCase (ind, npars) mch brs) fuel_sem.OOT _ _ |- _ ] =>
           remember (EAst.tCase (ind, npars) mch brs) as e_case in Hstep;
           remember fuel_sem.OOT as r_oot in Hstep;
@@ -947,7 +940,7 @@ Section Divergence.
         destruct Hcase_val as [src_v [f_case [t_case Hcase_val]]].
         destruct (@fuel_sem.src_eval_case_val_scrut
                     nat src_fuel_res src_trace_res
-                    Σ box_dc rho ind npars mch brs src_v f_case t_case Hcase_val)
+                    Σ rho ind npars mch brs src_v f_case t_case Hcase_val)
           as [dc [vs [f1 [t1 Hmch_val]]]].
         apply Hnoval. eexists _, _, _. exact Hmch_val.
       + destruct (Hdiv_case (S f)) as [t_case Hoot_case].
@@ -970,7 +963,7 @@ Section Divergence.
     inversion Hoot_case; subst.
     - simpl in H. lia.
     - match goal with
-      | [ Hstep : @eval_env_step _ _ _ Σ box_dc rho
+      | [ Hstep : @eval_env_step _ _ _ Σ rho
                      (EAst.tCase (ind, npars) mch brs) fuel_sem.OOT _ _ |- _ ] =>
           remember (EAst.tCase (ind, npars) mch brs) as e_case in Hstep;
           remember fuel_sem.OOT as r_oot in Hstep;
@@ -1016,7 +1009,7 @@ Section Divergence.
         destruct Hcase_val as [src_v [f_case [t_case Hcase_val]]].
         destruct (@fuel_sem.src_eval_case_val_body
                     nat src_fuel_res src_trace_res
-                    Σ box_dc rho ind npars mch brs dc vs body c src_v
+                    Σ rho ind npars mch brs dc vs body c src_v
                     f1 t1 f_case t_case Hmch Hdc Hfind Hcase_val)
           as [f2 [t2 Hbody_val]].
         apply Hnoval. eexists _, _, _. exact Hbody_val.
@@ -1038,7 +1031,7 @@ Section Divergence.
     inversion Hoot_proj; subst.
     - simpl in H. lia.
     - match goal with
-      | [ Hstep : @eval_env_step _ _ _ Σ box_dc rho
+      | [ Hstep : @eval_env_step _ _ _ Σ rho
                      (EAst.tProj p c) fuel_sem.OOT _ _ |- _ ] =>
           remember (EAst.tProj p c) as e_proj in Hstep;
           remember fuel_sem.OOT as r_oot in Hstep;
@@ -1064,7 +1057,7 @@ Section Divergence.
         destruct Hproj_val as [src_v [f_proj [t_proj Hproj_val]]].
         destruct (@fuel_sem.src_eval_proj_val_scrut
                     nat src_fuel_res src_trace_res
-                    Σ box_dc rho p c src_v f_proj t_proj Hproj_val)
+                    Σ rho p c src_v f_proj t_proj Hproj_val)
           as [vs [f1 [t1 Hc_val]]].
         apply Hnoval. eexists _, _, _. exact Hc_val.
       + destruct (Hdiv_proj (S f)) as [t_proj Hoot_proj].
@@ -1106,7 +1099,7 @@ Section Divergence.
         (args_done : list EAst.term) (e : EAst.term) (args_rest : list EAst.term)
         (vs_done : list fuel_sem.value) (fs ts f t : nat) :
     @fuel_sem.eval_fuel_many nat src_fuel_res src_trace_res
-                             Σ box_dc rho args_done vs_done fs ts ->
+                             Σ rho args_done vs_done fs ts ->
     (forall src_v f' t', ~ src_eval rho e (fuel_sem.Val src_v) f' t') ->
     src_eval rho (EAst.tConstruct ind c (args_done ++ e :: args_rest))
                  fuel_sem.OOT (fs + f + 1) t ->
@@ -1128,13 +1121,13 @@ Section Divergence.
         rewrite Hprefix in Hdone.
         edestruct (@fuel_sem.eval_many_app_inv
                       nat src_fuel_res src_trace_res
-                      Σ box_dc rho args_done0 e0 prefix _ _ _ Hdone)
+                      Σ rho args_done0 e0 prefix _ _ _ Hdone)
           as (vs_before & v_bad & vs_after & fs_before & f_val & fs_after &
               ts_before & t_val & ts_after &
               _ & Hmany_before & Hval_bad & Hmany_after & Hfs_done & _).
         pose proof (@fuel_sem.eval_many_exact_det
                       nat src_fuel_res src_trace_res
-                      Σ box_dc rho args_done0 _ _ _ _ _ _ H1 Hmany_before)
+                      Σ rho args_done0 _ _ _ _ _ _ H1 Hmany_before)
           as [_ [Hfs_prefix _]].
         pose proof (src_eval_val_gt_oot _ _ _ _ _ Hval_bad _ _ H2) as Hlt_bad.
         rewrite <- Hfs_prefix in Hfs_done.
@@ -1143,7 +1136,7 @@ Section Divergence.
       + destruct Hsame as [-> [-> ->]].
         pose proof (@fuel_sem.eval_many_exact_det
                       nat src_fuel_res src_trace_res
-                      Σ box_dc rho _ _ _ _ _ _ _ H1 Hdone)
+                      Σ rho _ _ _ _ _ _ _ H1 Hdone)
           as [_ [Hfs_eq _]].
         simpl in H. subst fs0.
         assert (Hff : f = f0) by lia.
@@ -1152,7 +1145,7 @@ Section Divergence.
         rewrite Hprefix in H1.
         edestruct (@fuel_sem.eval_many_app_inv
                       nat src_fuel_res src_trace_res
-                      Σ box_dc rho args_done e prefix _ _ _ H1)
+                      Σ rho args_done e prefix _ _ _ H1)
           as (vs_before & v_bad & vs_after & fs_before & f_val & fs_after &
               ts_before & t_val & ts_after &
               _ & _ & Hval_bad & _ & _ & _).
@@ -1164,7 +1157,7 @@ Section Divergence.
         (args_done : list EAst.term) (e : EAst.term) (args_rest : list EAst.term)
         (vs_done : list fuel_sem.value) (fs ts : nat) :
     @fuel_sem.eval_fuel_many nat src_fuel_res src_trace_res
-                             Σ box_dc rho args_done vs_done fs ts ->
+                             Σ rho args_done vs_done fs ts ->
     src_not_stuck rho (EAst.tConstruct ind c (args_done ++ e :: args_rest)) ->
     src_not_stuck rho e.
   Proof.
@@ -1178,7 +1171,7 @@ Section Divergence.
         destruct Hcon_val as [src_v [f_con [t_con Hcon_val]]].
         destruct (@fuel_sem.src_eval_construct_val_arg
                     nat src_fuel_res src_trace_res
-                    Σ box_dc rho ind c args_done e args_rest src_v
+                    Σ rho ind c args_done e args_rest src_v
                     f_con t_con Hcon_val)
           as [v_e [f_e [t_e Hval_e]]].
         apply Hnoval. eexists _, _, _. exact Hval_e.
@@ -1229,7 +1222,7 @@ Section Divergence.
     well_formed_env Σ rho ->
     Forall (fun e => wellformed Σ (List.length rho) e = true) es ->
     @eval_fuel_many nat src_fuel_res src_trace_res
-                    Σ box_dc rho es vs f t ->
+                    Σ rho es vs f t ->
     Forall (well_formed_val Σ) vs.
   Proof.
     intros Hwf_env Hwf_es Hmany.
@@ -1316,7 +1309,7 @@ Section Divergence.
   Lemma anf_cvt_correct_exps_proof
         vs_env es vs1 f t :
     @eval_fuel_many nat src_fuel_res src_trace_res
-                    Σ box_dc vs_env es vs1 f t ->
+                    Σ vs_env es vs1 f t ->
     anf_cvt_correct_exps' vs_env es vs1 f t.
   Proof.
     intros Hmany.
@@ -1364,7 +1357,7 @@ Section Divergence.
             intros k0 Hk0. unfold kn_deps_list. constructor. exact Hk0. }
           pose proof (anf_cvt_correct
                         func_tag default_tag default_itag tgm cmap cenv Σ
-                        dcon_to_tag_inj box_dc box_tag cenv_case_consistent
+                        dcon_to_tag_inj cenv_case_consistent
                         Hcmap_eval_coherent Hglob_term Hglob_fuel_zero Hglob_wf val_rel_exists
                         rho0 e0 (fuel_sem.Val v0) f0 t0 Heval_e)
             as Hcorr_head.
@@ -1483,7 +1476,7 @@ Section Divergence.
                  [symmetry; eapply eval_fuel_many_length; eassumption
                  | eapply Forall2_length; exact Hrel_tail]. }
              destruct (@anf_correct.set_many_get_in
-                         func_tag default_tag tgm cmap Σ box_dc box_tag
+                         func_tag default_tag tgm cmap Σ
                          x1 xs0 l' (M.set x1 y rho_tgt) Hin_x1 Hlen)
                as [v_sm Hget_sm].
              eexists. split. { exact Hget_sm. }
@@ -1506,7 +1499,7 @@ Section Divergence.
                              func_tag default_tag tgm cmap
                              S2 es0 vnames S' C2 xs0 Hcvt_tail).
                pose proof (@anf_correct.eval_fuel_many_length
-                             default_tag tgm Σ box_dc box_tag
+                             Σ
                              rho0 es0 vs0 fs0 ts0 Hmany).
                lia. }
              destruct Hk0_vs as [v_k0 Hv_k0].
@@ -1516,7 +1509,7 @@ Section Divergence.
                          Hcvt_tail k0 e_k0 x1 He_k0 Hk0_xs)
                as [S_k [S_k' [C_k [Hcvt_k Hsub_k]]]].
              destruct (@anf_correct.eval_fuel_many_nth
-                         default_tag tgm Σ box_dc box_tag
+                         Σ
                          rho0 es0 vs0 fs0 ts0 k0 e_k0 v_k0
                          Hmany He_k0 Hv_k0)
                as [f_k [t_k Heval_k]].
@@ -1593,7 +1586,7 @@ Section Divergence.
                    eapply eval_val_det; eassumption. }
              subst v_k0.
              destruct (@anf_correct.set_many_In_nth
-                         func_tag default_tag tgm cmap Σ box_dc box_tag
+                         func_tag default_tag tgm cmap Σ
                          x1 xs0 l' (M.set x1 y rho_tgt) v_sm Hget_sm Hin_x1 Hlen)
                as [j [Hj_xs Hj_vs]].
              assert (Hj_vs0 : exists v_j, nth_error vs0 j = Some v_j /\ anf_val_rel' v_j v_sm).
@@ -1616,7 +1609,7 @@ Section Divergence.
                            Hcvt_tail j e_j x1 He_j Hj_xs)
                  as [S_j [S_j' [C_j [Hcvt_j Hsub_j]]]].
                destruct (@anf_correct.eval_fuel_many_nth
-                           default_tag tgm Σ box_dc box_tag
+                           Σ
                            rho0 es0 vs0 fs0 ts0 j e_j v_j
                            Hmany He_j Hv_j)
                  as [f_j [t_j Heval_j]].
@@ -1692,7 +1685,7 @@ Section Divergence.
                        _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                        eq_fuel_compat' (fun _ _ H => H)
                        nat src_fuel_res src_trace_res
-                       Σ box_dc Hglob_term func_tag default_tag);
+                       Σ Hglob_term func_tag default_tag);
                [exact Hrel_head | exact Hrel_j].
           -- eexists. split.
             { rewrite (@anf_correct.set_many_get_notin
@@ -1722,7 +1715,7 @@ Section Divergence.
   Lemma anf_env_rel_set_many_args
         rho_src es vs_src f t :
     @eval_fuel_many nat src_fuel_res src_trace_res
-                    Σ box_dc rho_src es vs_src f t ->
+                    Σ rho_src es vs_src f t ->
     forall rho_tgt vnames S S' C xs vs_tgt,
       env_consistent vnames rho_src ->
       cmap_consistent' vnames rho_src ->
@@ -1762,7 +1755,7 @@ Section Divergence.
   Lemma global_env_rel_set_many_args
         rho_src es vs_src f t :
     @eval_fuel_many nat src_fuel_res src_trace_res
-                    Σ box_dc rho_src es vs_src f t ->
+                    Σ rho_src es vs_src f t ->
     forall rho_tgt vnames S S' C xs vs_tgt D,
       env_consistent vnames rho_src ->
       cmap_consistent' vnames rho_src ->
@@ -1803,7 +1796,7 @@ Section Divergence.
   Lemma anf_cvt_correct_exps_oot
         vs_env es vs1 f t rho vnames C xs S S' e_k vs' c :
     @eval_fuel_many nat src_fuel_res src_trace_res
-                    Σ box_dc vs_env es vs1 f t ->
+                    Σ vs_env es vs1 f t ->
     well_formed_env Σ vs_env ->
     Forall (fun e => wellformed Σ (List.length vnames) e = true) es ->
     env_consistent vnames vs_env ->
@@ -1858,7 +1851,7 @@ Section Divergence.
     intros Hwf Hwfe Hcons Hcmap Hdis Hdis_cmap Henv Hglob Hrel Hdis_ek Heval Hvrel.
     pose proof (anf_cvt_correct
                   func_tag default_tag default_itag tgm cmap cenv Σ
-                  dcon_to_tag_inj box_dc box_tag cenv_case_consistent
+                  dcon_to_tag_inj cenv_case_consistent
                   Hcmap_eval_coherent Hglob_term Hglob_fuel_zero Hglob_wf val_rel_exists
                   vs e (fuel_sem.Val v) f t Heval)
       as Hcorr.
@@ -2002,7 +1995,7 @@ Section Divergence.
   Proof.
     intros Hwf Hwfe Hcons Hcmap Hdis Hdis_cmap Henv Hglob Hrel Hoot_src Hval_src.
     assert (Hlen_env : List.length vs = List.length vnames).
-    { exact (@anf_env_rel_length func_tag default_tag tgm cmap Σ box_dc box_tag
+    { exact (@anf_env_rel_length func_tag default_tag tgm cmap Σ
                                  _ _ _ Henv). }
     assert (Hlt : f_oot < f_val).
     { eapply src_eval_val_gt_oot; eauto. }
@@ -2029,7 +2022,7 @@ Section Divergence.
            Hwf Hwfe Hcons Hcmap Hdis Hdis_cmap Henv Hglob Hrel
            e_k Hdis_ek _.
     assert (Hlen_env : List.length vs = List.length vnames).
-    { exact (@anf_env_rel_length func_tag default_tag tgm cmap Σ box_dc box_tag
+    { exact (@anf_env_rel_length func_tag default_tag tgm cmap Σ
                                  _ _ _ Henv). }
     assert (Hlt : f_oot < f_val).
     { eapply src_eval_val_gt_oot; eauto. }
@@ -2263,7 +2256,7 @@ Section Divergence.
           set (rho_bc := M.set x0 v2' (def_funs defs_cc defs_cc rho1 rho1)).
           assert (Hwf_body : wellformed Σ (Datatypes.S (Datatypes.length names)) body_clos = true).
           { inversion Hwf_clos; subst.
-            rewrite <- (@anf_env_rel_length func_tag default_tag tgm cmap Σ box_dc box_tag
+            rewrite <- (@anf_env_rel_length func_tag default_tag tgm cmap Σ
                                          _ _ _ Henv_clos).
             exact H3. }
           assert (Hcons_body : env_consistent (x0 :: names) (varg :: rho_clos)).
@@ -2421,7 +2414,7 @@ Section Divergence.
                   _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                   eq_fuel_compat' (fun _ _ H0 => H0)
                   nat src_fuel_res src_trace_res
-                  Σ box_dc Hglob_term func_tag default_tag).
+                  Σ Hglob_term func_tag default_tag).
                 exact Hrel_clos_saved.
                 exact Hrel_rho.
               - intros m0.
@@ -2429,7 +2422,7 @@ Section Divergence.
                   _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                   eq_fuel_compat' (fun _ _ H0 => H0)
                   nat src_fuel_res src_trace_res
-                  Σ box_dc Hglob_term func_tag default_tag).
+                  Σ Hglob_term func_tag default_tag).
                 rewrite Heq_varg in Hrel_rho. exact Hrel_rho.
                 exact Hrel_v2. }
             assert (Hpv_inst := Hpv_cv (c3 + 1)%nat).
@@ -3153,7 +3146,7 @@ Section Divergence.
             assert (Hfl : Datatypes.length fnames = Datatypes.length mfix)
               by (eapply anf_fix_rel_fnames_length; exact H17).
             assert (Hle : Datatypes.length names = Datatypes.length rho').
-            { symmetry. exact (@anf_env_rel_length func_tag default_tag tgm cmap Σ box_dc box_tag
+            { symmetry. exact (@anf_env_rel_length func_tag default_tag tgm cmap Σ
                                                _ _ _ H7). }
             rewrite Hfl, Hle.
             inversion Hwf_fix as [| | ? ? ? Hwf_rho' Hidx_bound Hwf_mfix_bodies].
@@ -3177,7 +3170,7 @@ Section Divergence.
                       x_pc (List.rev fnames ++ names) v2
                       (fuel_sem.make_rec_env mfix rho')).
             - eapply (@anf_correct.env_consistent_make_rec_env
-                        func_tag default_tag tgm cmap Σ box_dc box_tag
+                        func_tag default_tag tgm cmap Σ
                         fnames names mfix rho');
                 [exact H10 | exact H8 | exact H14 |].
               eapply anf_fix_rel_fnames_length. exact H17.
@@ -3188,7 +3181,7 @@ Section Divergence.
                              (v2 :: fuel_sem.make_rec_env mfix rho')).
           { eapply cmap_consistent_extend.
             - eapply (@anf_correct.cmap_consistent_make_rec_env
-                        func_tag default_tag tgm cmap Σ box_dc box_tag
+                        func_tag default_tag tgm cmap Σ
                         fnames names mfix rho');
                 [exact H9 | exact H13 |].
               eapply anf_fix_rel_fnames_length. exact H17.
@@ -3355,7 +3348,7 @@ Section Divergence.
                   _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                   eq_fuel_compat' (fun _ _ H0 => H0)
                   nat src_fuel_res src_trace_res
-                  Σ box_dc Hglob_term func_tag default_tag).
+                  Σ Hglob_term func_tag default_tag).
                 exact Hrel_fix_saved.
                 exact Hrel_rho.
               - intros m0.
@@ -3363,7 +3356,7 @@ Section Divergence.
                   _ _ _ _ eq_fuel eq_fuel tgm cmap cenv
                   eq_fuel_compat' (fun _ _ H0 => H0)
                   nat src_fuel_res src_trace_res
-                  Σ box_dc Hglob_term func_tag default_tag).
+                  Σ Hglob_term func_tag default_tag).
                 rewrite Heq_v2 in Hrel_rho. exact Hrel_rho.
                 exact Hrel_v2. }
             assert (Hpv_inst := Hpv_cv (c3 + 1)%nat).
@@ -3590,11 +3583,9 @@ Section Divergence.
                   assert (Heq_bind : v1 = v0 /\ f1 = f3 /\ t1 = t4)
                     by (eapply (@fuel_sem.eval_val_exact_det
                                   nat
-                                  (LambdaBox_resource_fuel
-                                     default_tag tgm box_dc box_tag)
-                                  (LambdaBox_resource_trace
-                                     default_tag tgm box_dc box_tag)
-                                  Σ box_dc); eauto).
+                                  (LambdaBox_resource_fuel)
+                                  (LambdaBox_resource_trace)
+                                  Σ); eauto).
                   destruct Heq_bind as [-> [-> ->]].
                   assert (f4 = f') by (simpl in H1; lia).
                   subst f4. rewrite Heqr_oot in H4. exists t5. exact H4.
@@ -3872,7 +3863,7 @@ Section Divergence.
           pose proof (Forall_inv Hwf_tail) as Hwfe1.
           assert (Hlen_env : Datatypes.length rho0 = Datatypes.length vn).
           { exact (@anf_env_rel_length
-                     func_tag default_tag tgm cmap Σ box_dc box_tag
+                     func_tag default_tag tgm cmap Σ
                      vn rho0 rho Henv). }
           assert (Hwf_done_rho :
                     Forall (fun e => wellformed Σ (Datatypes.length rho0) e = true)
@@ -4411,7 +4402,7 @@ Section Divergence.
             apply Bool.andb_true_iff in Hwfe_lhs as [_ Hwfe_m].
             exact Hwfe_m. }
           assert (Hlen_env : Datatypes.length rho0 = Datatypes.length vnames).
-          { exact (@anf_env_rel_length func_tag default_tag tgm cmap Σ box_dc box_tag
+          { exact (@anf_env_rel_length func_tag default_tag tgm cmap Σ
                                        _ _ _ Henv). }
           assert (Hwf_con : well_formed_val Σ (fuel_sem.Con_v (dcon_of_con ind c) vs0)).
           { eapply eval_preserves_wf; [exact Hglob_wf | exact Hwf | | exact H].
@@ -4431,7 +4422,7 @@ Section Divergence.
                                         (Vconstr c_tag vs_anf)).
           { constructor; [exact HF2_vs | reflexivity]. }
           edestruct (@anf_cvt_rel_branches_find_branch
-                       func_tag default_tag tgm cmap Σ dcon_to_tag_inj box_dc box_tag
+                       func_tag default_tag tgm cmap Σ dcon_to_tag_inj
                        S2 ind brs 0%N vnames y S3 pats c (Datatypes.length vs0) body
                        Hcvt_brs H1)
             as (br_vars & S_br & S_br_out & C_br & r_br & ctx_br & m_br &
@@ -4509,13 +4500,13 @@ Section Divergence.
               with (Datatypes.length vnames + Datatypes.length vs0)
               by (rewrite Hbr_len; lia).
             eapply (@anf_correct.find_branch_wellformed
-                      default_tag tgm efl box_dc box_tag
+                      efl
                       Σ (Datatypes.length vnames) ind npars mch brs
                       c (Datatypes.length vs0) body);
               [exact Hwfe | exact H1]. }
           assert (Hcons_body : env_consistent (br_vars ++ vnames) (rev vs0 ++ rho0)).
           { eapply (@env_consistent_app
-                      func_tag default_tag tgm cmap Σ box_dc box_tag
+                      func_tag default_tag tgm cmap Σ
                       br_vars vnames (rev vs0) rho0).
             - exact Hbr_nd.
             - exact Hcons.
@@ -4528,7 +4519,7 @@ Section Divergence.
             - rewrite Hbr_len. rewrite length_rev. reflexivity. }
           assert (Hcmap_body : cmap_consistent' (br_vars ++ vnames) (rev vs0 ++ rho0)).
           { eapply (@cmap_consistent_app
-                      func_tag default_tag tgm cmap Σ box_dc box_tag
+                      func_tag default_tag tgm cmap Σ
                       br_vars vnames (rev vs0) rho0).
             - exact Hcmap.
             - eapply Disjoint_Included_r; [| exact Hdis_cmap].
@@ -4677,7 +4668,7 @@ Section Divergence.
                      (ctx_br |[ C_br |[ Ehalt r_br ]| ]|, rho_match)).
           { subst ctx_br.
             eapply (@anf_correct.ctx_bind_proj_preord_exp
-                      func_tag default_tag tgm cmap cenv Σ box_dc box_tag
+                      func_tag default_tag tgm cmap cenv Σ
                       br_vars
                       (ctx_bind_proj c_tag y br_vars (Datatypes.length br_vars))
                       c3 y (Datatypes.length br_vars)
@@ -4703,7 +4694,7 @@ Section Divergence.
                      (ctx_br |[ C_br |[ Ehalt r_br ]| ]|, rho_match)
                      (Ecase y pats, rho_match)).
           { eapply (@preord_exp_Ecase_red
-                      func_tag default_tag tgm cmap cenv Σ box_dc box_tag
+                      func_tag default_tag tgm cmap cenv Σ
                       cenv_case_consistent c_ctx rho_match c_tag vs_anf pats
                       (ctx_br |[ C_br |[ Ehalt r_br ]| ]|) m_br y).
             - unfold rho_match. rewrite M.gss. reflexivity.

--- a/theories/LambdaBox_to_LambdaANF/anf_global.v
+++ b/theories/LambdaBox_to_LambdaANF/anf_global.v
@@ -41,11 +41,8 @@ Section ValRelWeaken.
 
   Context {efl : EEnvFlags}.
 
-  Context (box_dc : dcon)
-          (box_tag : dcon_to_tag default_tag box_dc tgm = default_tag).
-
-  Let Hf_src := LambdaBox_resource_fuel default_tag tgm box_dc box_tag.
-  Let Ht_src := LambdaBox_resource_trace default_tag tgm box_dc box_tag.
+  Let Hf_src := LambdaBox_resource_fuel.
+  Let Ht_src := LambdaBox_resource_trace.
 
   (** Full (source) parameters *)
   Context (cmap_full : const_map) (Σ_full : EAst.global_context).
@@ -67,9 +64,9 @@ Section ValRelWeaken.
     exists decl, EGlobalEnv.declared_constant Σ_tail k decl).
 
   Let anf_val_rel_full :=
-    @anf_val_rel func_tag default_tag tgm cmap_full nat Hf_src Ht_src Σ_full box_dc.
+    @anf_val_rel func_tag default_tag tgm cmap_full nat Hf_src Ht_src Σ_full.
   Let anf_val_rel_part :=
-    @anf_val_rel func_tag default_tag tgm cm nat Hf_src Ht_src Σ_tail box_dc.
+    @anf_val_rel func_tag default_tag tgm cm nat Hf_src Ht_src Σ_tail.
 
   (* Helper: transfer Forall2 using pointwise IH + a generic side condition Q *)
   Lemma forall2_val_rel_weaken (Q : fuel_sem.value -> Prop) vs :
@@ -109,8 +106,8 @@ Section ValRelWeaken.
 
   (* Helper: weaken cmap_consistent from (cmap_full, Σ_full) to (cm, Σ_tail) *)
   Lemma cmap_consistent_weaken names vs :
-    @cmap_consistent cmap_full _ Hf_src Ht_src Σ_full box_dc names vs ->
-    @cmap_consistent cm _ Hf_src Ht_src Σ_tail box_dc names vs.
+    @cmap_consistent cmap_full _ Hf_src Ht_src Σ_full names vs ->
+    @cmap_consistent cm _ Hf_src Ht_src Σ_tail names vs.
   Proof.
     intros Hcm_c i x k decl body Hnth Hlk Hdecl Hbody.
     (* Bridge lookups: cm → cmap_full, Σ_tail → Σ_full *)
@@ -122,7 +119,7 @@ Section ValRelWeaken.
     (* Restrict eval from Σ_full to Σ_tail *)
     assert (Hwf_body : wellformed Σ_tail 0 body = true).
     { exact (wf_glob_globals_wf Σ_tail Hwf_tail _ _ _ Hdecl Hbody). }
-    exact (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src Σ_full box_dc Σ_tail
+    exact (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src Σ_full Σ_tail
                     [] body (fuel_sem.Val v_i) f0 t0 Hwf_tail Hext
                     ltac:(constructor) Hwf_body Heval_full)).
   Qed.
@@ -277,13 +274,13 @@ Section ValRelWeaken.
       + (* Con_v *)
         inversion Hwf as [? ? Hwf_vs| |]; subst.
         inversion Hrel; subst.
-        apply (@anf_rel_Con func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail box_dc);
+        apply (@anf_rel_Con func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail);
           [| reflexivity].
         eapply (forall2_val_rel_weaken (well_formed_val [])); eassumption.
       + (* Clos_v *)
         inversion Hwf as [|? ? ? Hwf_vs Hwf_body|]; subst.
         inversion Hrel; subst.
-        eapply (@anf_rel_Clos func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail box_dc);
+        eapply (@anf_rel_Clos func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail);
           try eassumption.
         * (* anf_env_rel' *)
           eapply (env_rel_val_rel_weaken (well_formed_val []));
@@ -311,7 +308,7 @@ Section ValRelWeaken.
       + (* ClosFix_v *)
         inversion Hwf as [| |? ? ? Hwf_vs Hidx Hwf_mfix]; subst.
         inversion Hrel; subst.
-        eapply (@anf_rel_ClosFix func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail box_dc);
+        eapply (@anf_rel_ClosFix func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail);
           try eassumption.
         * eapply (env_rel_val_rel_weaken (well_formed_val []));
             [exact H | eassumption | exact Hwf_vs].
@@ -359,13 +356,13 @@ Section ValRelWeaken.
       + (* Con_v *)
         inversion Hwf as [? ? Hwf_vs| |]; subst.
         inversion Hrel; subst.
-        apply (@anf_rel_Con func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail box_dc);
+        apply (@anf_rel_Con func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail);
           [| reflexivity].
         eapply (forall2_val_rel_weaken (well_formed_val ((kn, d) :: Σ'))); eassumption.
       + (* Clos_v *)
         inversion Hwf as [|? ? ? Hwf_vs Hwf_body|]; subst.
         inversion Hrel; subst.
-        eapply (@anf_rel_Clos func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail box_dc);
+        eapply (@anf_rel_Clos func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail);
           try eassumption.
         * eapply (env_rel_val_rel_weaken (well_formed_val ((kn, d) :: Σ')));
             [exact H | eassumption | exact Hwf_vs].
@@ -385,7 +382,7 @@ Section ValRelWeaken.
             by (simpl; rewrite Hlen; reflexivity).
           eapply EWellformed.extends_wellformed; [exact Hwf_tail | exact Hext0 | exact Hwf_body].
         * (* global_env_rel' part — use OUTER IH *)
-          match goal with H : global_env_rel' _ _ _ _ _ _ |- _ =>
+          match goal with H : global_env_rel' _ _ _ _ _ |- _ =>
             rename H into Hglob end.
           intros k v_g Hkdep Hlk_cm.
           pose proof (Hcm_sub _ _ Hlk_cm) as Hlk_full.
@@ -426,9 +423,9 @@ Section ValRelWeaken.
           split; [exact Hdecl_tail |]. split; [exact Hbody |]. split; [exact Hget |].
           intros src_v f0 t0 Heval_tail.
           (* Lift eval Σ_tail → eval Σ_full *)
-          assert (Heval_full : @eval_env_fuel _ Hf_src Ht_src Σ_full box_dc []
+          assert (Heval_full : @eval_env_fuel _ Hf_src Ht_src Σ_full []
                                 body (fuel_sem.Val src_v) f0 t0).
-          { exact (@eval_env_fuel_extends _ Hf_src Ht_src Σ_full box_dc
+          { exact (@eval_env_fuel_extends _ Hf_src Ht_src Σ_full
                      Σ_tail [] body _ f0 t0 Hext Heval_tail). }
           pose proof (Hrel_glob src_v f0 t0 Heval_full) as Hrel_full.
           (* Establish wellformed Σ' 0 body for use in eval_preserves_wf_restricted *)
@@ -442,14 +439,14 @@ Section ValRelWeaken.
               unfold declared_constant. exact Hlk_some. }
           (* Apply eval_preserves_wf_restricted to get well_formed_val Σ' *)
           assert (Hwf_src : well_formed_val Σ' src_v).
-          { eapply (@eval_preserves_wf_restricted _ _ Hf_src Ht_src Σ_full box_dc Σ');
+          { eapply (@eval_preserves_wf_restricted _ _ Hf_src Ht_src Σ_full Σ');
               [exact Hwf' | exact Hext_full | constructor | exact Hwf_body_Σ' | exact Heval_full]. }
           (* Apply outer IH *)
           eapply IH; [exact Hwf_src | exact Hrel_full].
       + (* ClosFix_v *)
         inversion Hwf as [| |? ? ? Hwf_vs Hidx Hwf_mfix]; subst.
         inversion Hrel; subst.
-        eapply (@anf_rel_ClosFix func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail box_dc);
+        eapply (@anf_rel_ClosFix func_tag default_tag tgm cm _ Hf_src Ht_src Σ_tail);
           try eassumption.
         * eapply (env_rel_val_rel_weaken (well_formed_val ((kn, d) :: Σ')));
             [exact H | eassumption | exact Hwf_vs].
@@ -471,7 +468,7 @@ Section ValRelWeaken.
           rewrite length_app, length_rev, Hlen_f, <- Hlen_n.
           eapply EWellformed.extends_wellformed; [exact Hwf_tail | exact Hext0 | exact Hwf_d].
         * (* global_env_rel' part — use OUTER IH (same logic as Clos) *)
-          match goal with H : global_env_rel' _ _ _ _ _ _ |- _ =>
+          match goal with H : global_env_rel' _ _ _ _ _ |- _ =>
             rename H into Hglob end.
           intros k v_g Hkdep Hlk_cm.
           pose proof (Hcm_sub _ _ Hlk_cm) as Hlk_full.
@@ -514,9 +511,9 @@ Section ValRelWeaken.
           exists decl, body, anf_v.
           split; [exact Hdecl_tail |]. split; [exact Hbody |]. split; [exact Hget |].
           intros src_v f0 t0 Heval_tail.
-          assert (Heval_full : @eval_env_fuel _ Hf_src Ht_src Σ_full box_dc []
+          assert (Heval_full : @eval_env_fuel _ Hf_src Ht_src Σ_full []
                                 body (fuel_sem.Val src_v) f0 t0).
-          { exact (@eval_env_fuel_extends _ Hf_src Ht_src Σ_full box_dc
+          { exact (@eval_env_fuel_extends _ Hf_src Ht_src Σ_full
                      Σ_tail [] body _ f0 t0 Hext Heval_tail). }
           pose proof (Hrel_glob src_v f0 t0 Heval_full) as Hrel_full.
           assert (Hwf_body_Σ' : wellformed Σ' 0 body = true).
@@ -526,7 +523,7 @@ Section ValRelWeaken.
             - eapply (wf_glob_globals_wf Σ' Hwf' k decl body); [| exact Hbody].
               unfold declared_constant. exact Hlk_some. }
           assert (Hwf_src : well_formed_val Σ' src_v).
-          { eapply (@eval_preserves_wf_restricted _ _ Hf_src Ht_src Σ_full box_dc Σ');
+          { eapply (@eval_preserves_wf_restricted _ _ Hf_src Ht_src Σ_full Σ');
               [exact Hwf' | exact Hext_full | constructor | exact Hwf_body_Σ' | exact Heval_full]. }
           eapply IH; [exact Hwf_src | exact Hrel_full].
   Qed.
@@ -570,42 +567,39 @@ Section GlobalBindingsCorrect.
     forall dc dc',
       dcon_to_tag default_tag dc tgm = dcon_to_tag default_tag dc' tgm -> dc = dc').
 
-  Context (box_dc : dcon)
-          (box_tag : dcon_to_tag default_tag box_dc tgm = default_tag).
-
   Context (cenv_case_consistent : forall P ctag, caseConsistent cenv P ctag).
 
-  Let Hf_src := LambdaBox_resource_fuel default_tag tgm box_dc box_tag.
-  Let Ht_src := LambdaBox_resource_trace default_tag tgm box_dc box_tag.
+  Let Hf_src := LambdaBox_resource_fuel.
+  Let Ht_src := LambdaBox_resource_trace.
 
   Context (Hcmap_eval_coherent :
-    @cmap_eval_coherent cmap _ Hf_src Ht_src Σ box_dc).
+    @cmap_eval_coherent cmap _ Hf_src Ht_src Σ).
 
   Let anf_val_rel' :=
-    @anf_val_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ box_dc.
+    @anf_val_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ.
 
   Let anf_cvt_rel' :=
     anf_cvt_rel func_tag default_tag tgm cmap.
 
   Let global_env_rel' :=
-    @global_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ box_dc.
+    @global_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ.
 
   Let anf_env_rel' :=
-    @anf_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ box_dc.
+    @anf_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ.
 
-  Let src_eval := @eval_env_fuel nat Hf_src Ht_src Σ box_dc.
+  Let src_eval := @eval_env_fuel nat Hf_src Ht_src Σ.
 
   (** Per-(cm,Σ') versions of the value, env, and global env relations. *)
   Local Notation val_rel_at cm0 Σ0 :=
-    (@anf_val_rel func_tag default_tag tgm cm0 nat Hf_src Ht_src Σ0 box_dc).
+    (@anf_val_rel func_tag default_tag tgm cm0 nat Hf_src Ht_src Σ0).
   Local Notation env_rel_at cm0 Σ0 :=
-    (@anf_env_rel func_tag default_tag tgm cm0 nat Hf_src Ht_src Σ0 box_dc).
+    (@anf_env_rel func_tag default_tag tgm cm0 nat Hf_src Ht_src Σ0).
   Local Notation glob_rel_at cm0 Σ0 :=
-    (@global_env_rel func_tag default_tag tgm cm0 nat Hf_src Ht_src Σ0 box_dc).
+    (@global_env_rel func_tag default_tag tgm cm0 nat Hf_src Ht_src Σ0).
   Local Notation cvt_rel_at cm0 :=
     (@anf_cvt_rel func_tag default_tag tgm cm0).
   Local Notation eval_at Σ0 :=
-    (@eval_env_fuel nat Hf_src Ht_src Σ0 box_dc).
+    (@eval_env_fuel nat Hf_src Ht_src Σ0).
 
   Context (Hglob_term :
     forall k decl body,
@@ -646,14 +640,14 @@ Section GlobalBindingsCorrect.
 
   Let val_rel_exists :=
     @anf_val_rel_exists func_tag default_tag prim_map tgm prims cmap
-      _ Σ box_dc nat Hf_src Ht_src
+      _ Σ nat Hf_src Ht_src
       Hglob_term Hwf_glob
       HnoVar HnoEvar HnoCoFix HnoLazy Hblocks HnoArray
       no_prims cmap_complete cmap_sound cmap_nodup_keys Hcmap_eval_coherent.
 
   Let cvt_correct :=
     @anf_cvt_correct func_tag default_tag kon_tag
-      tgm cmap cenv Σ _ dcon_to_tag_inj box_dc box_tag
+      tgm cmap cenv Σ _ dcon_to_tag_inj
       cenv_case_consistent Hcmap_eval_coherent
       Hglob_term Hglob_fuel_zero Hglob_wf val_rel_exists.
 
@@ -756,7 +750,7 @@ Section GlobalBindingsCorrect.
                      declared_constant Σ_proc k decl /\
                      decl.(EAst.cst_body) = Some body) ->
       NoDup (map fst cm_acc) ->
-      @cmap_eval_coherent cm_acc _ Hf_src Ht_src Σ_proc box_dc ->
+      @cmap_eval_coherent cm_acc _ Hf_src Ht_src Σ_proc ->
       forall body v C S S' rho src_v f t,
         wellformed Σ_proc 0 body = true ->
         cvt_rel_at cm_acc S body [] S' C v ->
@@ -809,7 +803,7 @@ Section GlobalBindingsCorrect.
       assert (Hwf_body0 : wellformed Σ_proc 0 body0 = true).
       { eapply wf_glob_globals_wf; eauto. }
       pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
-                           Σ box_dc Σ_proc
+                           Σ Σ_proc
                            [] body0 (fuel_sem.Val src_v0) f0 t0
                            Hwf_proc Hext_proc ltac:(constructor)
                            Hwf_body0 Heval_full))
@@ -826,7 +820,7 @@ Section GlobalBindingsCorrect.
       unfold declared_constant in Hdecl_proc.
       pose proof (Hext_proc _ _ Hdecl_proc) as Hdecl_full.
       pose proof (@eval_env_fuel_extends _ Hf_src Ht_src
-                    Σ box_dc Σ_proc
+                    Σ Σ_proc
                     [] body0 (fuel_sem.Val src_v0) f0 t0
                     Hext_proc Heval_proc) as Heval_full.
       eapply Hglob_fuel_zero.
@@ -853,7 +847,7 @@ Section GlobalBindingsCorrect.
     }
     assert (Hcons : @env_consistent [] []).
     { intros i0 j0 x0 Hi. rewrite nth_error_nil in Hi. discriminate. }
-    assert (Hcmap_c : @cmap_consistent cm_acc _ Hf_src Ht_src Σ_proc box_dc [] []).
+    assert (Hcmap_c : @cmap_consistent cm_acc _ Hf_src Ht_src Σ_proc [] []).
     { intros i0 x0 k0 decl0 body0 Hnth. rewrite nth_error_nil in Hnth. discriminate. }
     assert (Hdis_fn : Disjoint _ (FromList []) S).
     { rewrite FromList_nil. now apply Disjoint_Empty_set_l. }
@@ -868,7 +862,7 @@ Section GlobalBindingsCorrect.
     { eapply anf_val_rel_weaken; eauto. }
     pose proof (@anf_cvt_correct
                   func_tag default_tag kon_tag
-                  tgm cm_acc cenv Σ_proc _ dcon_to_tag_inj box_dc box_tag
+                  tgm cm_acc cenv Σ_proc _ dcon_to_tag_inj
                   cenv_case_consistent Hcoh_acc
                   Hglob_term_proc Hglob_fuel_zero_proc Hglob_wf_proc Hval_rel_exists_acc
                   [] body (fuel_sem.Val src_v) f t Heval)
@@ -1061,8 +1055,8 @@ Section GlobalBindingsCorrect.
        exists decl body,
          declared_constant Σ_tail k0 decl /\
          decl.(EAst.cst_body) = Some body) ->
-    @cmap_eval_coherent cm _ Hf_src Ht_src Σ_tail box_dc ->
-    @cmap_eval_coherent cm _ Hf_src Ht_src ((k, d) :: Σ_tail) box_dc.
+    @cmap_eval_coherent cm _ Hf_src Ht_src Σ_tail ->
+    @cmap_eval_coherent cm _ Hf_src Ht_src ((k, d) :: Σ_tail).
   Proof.
     intros Hwf_cons Hcm_sound_tail Hcoh
            k1 k2 x decl1 body1 decl2 body2 src_v f t
@@ -1091,7 +1085,7 @@ Section GlobalBindingsCorrect.
     assert (Hwf_body1_tail : wellformed Σ_tail 0 body1 = true).
     { exact (wf_glob_globals_wf Σ_tail Hwf_tail _ _ _ Hdecl1_tail Hbody1). }
     pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
-                         ((k, d) :: Σ_tail) box_dc Σ_tail
+                         ((k, d) :: Σ_tail) Σ_tail
                          [] body1 (fuel_sem.Val src_v) f t
                          Hwf_tail Hext_tail ltac:(constructor)
                          Hwf_body1_tail Heval1))
@@ -1121,7 +1115,7 @@ Section GlobalBindingsCorrect.
                      decl.(EAst.cst_body) = Some body) ->
       NoDup (map fst cm_acc) ->
       Disjoint _ (cmap_vars cm_acc) S ->
-      @cmap_eval_coherent cm_acc _ Hf_src Ht_src Σ_proc box_dc ->
+      @cmap_eval_coherent cm_acc _ Hf_src Ht_src Σ_proc ->
       forall rho_init,
         global_env_rel' (fun k => lookup_const cm_acc k <> None) rho_init ->
         exists rho_g F T,
@@ -1258,7 +1252,7 @@ Section GlobalBindingsCorrect.
         split; [exact Hget0 |].
         intros src_v1 f1 t1 Heval_proc.
         assert (Heval_full :
-          @eval_env_fuel _ Hf_src Ht_src Σ box_dc []
+          @eval_env_fuel _ Hf_src Ht_src Σ []
             body_full (fuel_sem.Val src_v1) f1 t1).
         { eapply eval_env_fuel_extends; eauto. }
         pose proof (Hrel0 _ _ _ Heval_full) as Hrel_full.
@@ -1268,7 +1262,7 @@ Section GlobalBindingsCorrect.
         assert (Hrel_part : val_rel_at cm0 Σ_proc src_v1 anf_v0).
         { exact (@anf_val_rel_weaken
                    func_tag default_tag tgm efl
-                   box_dc box_tag
+                  
                    cmap Σ
                    cm0 Σ_proc
                    Hwf_proc Hext_proc
@@ -1284,7 +1278,7 @@ Section GlobalBindingsCorrect.
         - exact Hlk. }
       assert (Heval_cur_proc : eval_at Σ_proc [] body (Val src_v) f t).
       { pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
-                           Σ box_dc Σ_proc
+                           Σ Σ_proc
                            [] body (fuel_sem.Val src_v) f t
                            Hwf_proc Hext_proc ltac:(constructor)
                            Hwf_body_proc Heval_cur))
@@ -1326,11 +1320,11 @@ Section GlobalBindingsCorrect.
       }
       assert (Hcoh_old1 :
         @cmap_eval_coherent cm0 _ Hf_src Ht_src
-          ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc) box_dc).
+          ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)).
       { eapply cmap_eval_coherent_lift_head; eauto. }
       assert (Hcoh_proc1 :
         @cmap_eval_coherent ((k, v) :: cm0) _ Hf_src Ht_src
-          ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc) box_dc).
+          ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)).
       { intros k1 k2 x decl1 body1 decl2 body2 src_v0 f0 t0
                Hlk1 Hlk2 Hdecl1 Hbody1 Hdecl2 Hbody2 Heval1.
         simpl in Hlk1, Hlk2.
@@ -1358,7 +1352,7 @@ Section GlobalBindingsCorrect.
             - exact Hdecl2. }
           pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
                                ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)
-                               box_dc Σ_proc
+                               Σ_proc
                                [] body (fuel_sem.Val src_v0) f0 t0
                                Hwf_proc Hext_proc_small ltac:(constructor)
                                Hwf_body_proc Heval1))
@@ -1367,10 +1361,10 @@ Section GlobalBindingsCorrect.
           { rewrite FromList_nil. now apply Disjoint_Empty_set_l. }
           assert (Hcons_nil : @env_consistent [] []).
           { intros i0 j0 x0 Hi. rewrite nth_error_nil in Hi. discriminate. }
-          assert (Hcmap_nil : @cmap_consistent cm0 _ Hf_src Ht_src Σ_proc box_dc [] []).
+          assert (Hcmap_nil : @cmap_consistent cm0 _ Hf_src Ht_src Σ_proc [] []).
           { intros i0 x0 k0 decl0 body0 Hnth. rewrite nth_error_nil in Hnth. discriminate. }
-          destruct (@anf_cvt_cmap_eval func_tag default_tag tgm cm0 Σ_proc box_dc
-                      box_tag Hcoh_acc
+          destruct (@anf_cvt_cmap_eval func_tag default_tag tgm cm0 Σ_proc
+                      Hcoh_acc
                       [] body src_v0 f0 t0 Heval1_tail
                       S0 [] S1 C v k2 decl2 body2
                       Hbody_cvt Hdis_nil Hdis_acc Hcons_nil Hcmap_nil
@@ -1378,7 +1372,7 @@ Section GlobalBindingsCorrect.
             as [f' [t' Heval2_tail]].
           exists f', t'. exact (@eval_env_fuel_extends _ Hf_src Ht_src
                                  ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)
-                                 box_dc Σ_proc [] body2 (fuel_sem.Val src_v0) f' t'
+                                 Σ_proc [] body2 (fuel_sem.Val src_v0) f' t'
                                  Hext_proc_small Heval2_tail).
         - apply eq_kername_bool_eq in Hk2. subst k2.
           injection Hlk2 as <-.
@@ -1396,7 +1390,7 @@ Section GlobalBindingsCorrect.
           { exact (wf_glob_globals_wf Σ_proc Hwf_proc _ _ _ Hdecl1_tail Hbody1). }
           pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
                                ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)
-                               box_dc Σ_proc
+                               Σ_proc
                                [] body1 (fuel_sem.Val src_v0) f0 t0
                                Hwf_proc Hext_proc_small ltac:(constructor)
                                Hwf_body1_tail Heval1))
@@ -1404,7 +1398,7 @@ Section GlobalBindingsCorrect.
           destruct (Hglob_term k {| EAst.cst_body := Some body |} body Hdecl_cur_full eq_refl)
             as [src_v_new [f_new [t_new Heval_new_full]]].
           pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
-                               Σ box_dc Σ_proc
+                               Σ Σ_proc
                                [] body (fuel_sem.Val src_v_new) f_new t_new
                                Hwf_proc Hext_proc ltac:(constructor)
                                Hwf_body_proc Heval_new_full))
@@ -1413,10 +1407,10 @@ Section GlobalBindingsCorrect.
           { rewrite FromList_nil. now apply Disjoint_Empty_set_l. }
           assert (Hcons_nil : @env_consistent [] []).
           { intros i0 j0 x0 Hi. rewrite nth_error_nil in Hi. discriminate. }
-          assert (Hcmap_nil : @cmap_consistent cm0 _ Hf_src Ht_src Σ_proc box_dc [] []).
+          assert (Hcmap_nil : @cmap_consistent cm0 _ Hf_src Ht_src Σ_proc [] []).
           { intros i0 x0 k0 decl0 body0 Hnth. rewrite nth_error_nil in Hnth. discriminate. }
-          destruct (@anf_cvt_cmap_eval func_tag default_tag tgm cm0 Σ_proc box_dc
-                      box_tag Hcoh_acc
+          destruct (@anf_cvt_cmap_eval func_tag default_tag tgm cm0 Σ_proc
+                      Hcoh_acc
                       [] body src_v_new f_new t_new Heval_new_tail
                       S0 [] S1 C v k1 decl1 body1
                       Hbody_cvt Hdis_nil Hdis_acc Hcons_nil Hcmap_nil
@@ -1426,7 +1420,7 @@ Section GlobalBindingsCorrect.
           subst src_v_new.
           exists f_new, t_new. exact (@eval_env_fuel_extends _ Hf_src Ht_src
                                  ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)
-                                 box_dc Σ_proc [] body (fuel_sem.Val src_v0) f_new t_new
+                                 Σ_proc [] body (fuel_sem.Val src_v0) f_new t_new
                                  Hext_proc_small Heval_new_tail).
         - assert (Hlk1_tail : lookup_const cm0 k1 = Some x) by exact Hlk1.
           assert (Hlk2_tail : lookup_const cm0 k2 = Some x) by exact Hlk2.
@@ -1518,7 +1512,7 @@ Section GlobalBindingsCorrect.
         assert (Hctx_body0 :
           occurs_free_ctx C \subset FromList [] :|: (S0 \\ S1) :|: cmap_vars cm0).
         { exact (@anf_cvt_occurs_free_ctx_exp
-                   func_tag default_tag tgm cm0 Σ_proc box_dc box_tag
+                   func_tag default_tag tgm cm0 Σ_proc
                    S0 body [] S1 C v
                    Hbody_cvt Hdis_nil Hdis_acc). }
         assert (Hctx_body : occurs_free_ctx C \subset (S0 \\ S1) :|: cmap_vars cm0).
@@ -1688,7 +1682,7 @@ Section GlobalBindingsCorrect.
 	        { exact Hbody0. } }
 	      assert (Hcoh_proc1 :
 	        @cmap_eval_coherent cm0 _ Hf_src Ht_src
-	          ((k, EAst.InductiveDecl ind) :: Σ_proc) box_dc).
+	          ((k, EAst.InductiveDecl ind) :: Σ_proc)).
 	      { eapply cmap_eval_coherent_lift_head.
 	        - exact Hwf_proc1.
 	        - exact Hcm_sound_proc.
@@ -1731,7 +1725,7 @@ Section GlobalBindingsCorrect.
                      decl.(EAst.cst_body) = Some body) ->
       NoDup (map fst cm_acc) ->
       Disjoint _ (cmap_vars cm_acc) S ->
-      @cmap_eval_coherent cm_acc _ Hf_src Ht_src Σ_proc box_dc ->
+      @cmap_eval_coherent cm_acc _ Hf_src Ht_src Σ_proc ->
       forall rho_init,
         global_env_rel' (fun k => lookup_const cm_acc k <> None) rho_init ->
         exists rho_g F T,
@@ -1769,16 +1763,13 @@ Section GlobalBindingsCoherence.
   Context {efl : EEnvFlags}.
   Context (HnoAxioms : has_axioms = false).
 
-  Context (box_dc : dcon)
-          (box_tag : dcon_to_tag default_tag box_dc tgm = default_tag).
-
-  Let Hf_src := LambdaBox_resource_fuel default_tag tgm box_dc box_tag.
-  Let Ht_src := LambdaBox_resource_trace default_tag tgm box_dc box_tag.
+  Let Hf_src := LambdaBox_resource_fuel.
+  Let Ht_src := LambdaBox_resource_trace.
 
   Local Notation cvt_rel_at cm0 :=
     (@anf_cvt_rel func_tag default_tag tgm cm0).
   Local Notation eval_at Σ0 :=
-    (@eval_env_fuel nat Hf_src Ht_src Σ0 box_dc).
+    (@eval_env_fuel nat Hf_src Ht_src Σ0).
 
   Context (Hglob_term :
     forall k decl body,
@@ -1930,8 +1921,8 @@ Section GlobalBindingsCoherence.
        exists decl body,
          declared_constant Σ_tail k0 decl /\
          decl.(EAst.cst_body) = Some body) ->
-    @cmap_eval_coherent cm _ Hf_src Ht_src Σ_tail box_dc ->
-    @cmap_eval_coherent cm _ Hf_src Ht_src ((k, d) :: Σ_tail) box_dc.
+    @cmap_eval_coherent cm _ Hf_src Ht_src Σ_tail ->
+    @cmap_eval_coherent cm _ Hf_src Ht_src ((k, d) :: Σ_tail).
   Proof.
     intros Hwf_cons Hcm_sound_tail Hcoh
            k1 k2 x decl1 body1 decl2 body2 src_v f t
@@ -1960,7 +1951,7 @@ Section GlobalBindingsCoherence.
     assert (Hwf_body1_tail : wellformed Σ_tail 0 body1 = true).
     { exact (wf_glob_globals_wf Σ_tail Hwf_tail _ _ _ Hdecl1_tail Hbody1). }
     pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
-                         ((k, d) :: Σ_tail) box_dc Σ_tail
+                         ((k, d) :: Σ_tail) Σ_tail
                          [] body1 (fuel_sem.Val src_v) f t
                          Hwf_tail Hext_tail ltac:(constructor)
                          Hwf_body1_tail Heval1))
@@ -1983,8 +1974,8 @@ Section GlobalBindingsCoherence.
                      declared_constant Σ_proc k decl /\
                      decl.(EAst.cst_body) = Some body) ->
       Disjoint _ (cmap_vars cm_acc) S ->
-      @cmap_eval_coherent cm_acc _ Hf_src Ht_src Σ_proc box_dc ->
-      @cmap_eval_coherent cmap _ Hf_src Ht_src Σ box_dc.
+      @cmap_eval_coherent cm_acc _ Hf_src Ht_src Σ_proc ->
+      @cmap_eval_coherent cmap _ Hf_src Ht_src Σ.
   Proof.
     intros Σ_proc gd cm_acc C_env S S' Hcvt.
     revert Σ_proc.
@@ -2055,11 +2046,11 @@ Section GlobalBindingsCoherence.
       { rewrite FromList_nil. now apply Disjoint_Empty_set_l. }
       assert (Hcons_nil : @env_consistent [] []).
       { intros i j x Hi. rewrite nth_error_nil in Hi. discriminate. }
-      assert (Hcmap_nil : @cmap_consistent cm0 _ Hf_src Ht_src Σ_proc box_dc [] []).
+      assert (Hcmap_nil : @cmap_consistent cm0 _ Hf_src Ht_src Σ_proc [] []).
       { intros i x k0 decl0 body0 Hnth. rewrite nth_error_nil in Hnth. discriminate. }
       assert (Hcoh_old1 :
         @cmap_eval_coherent cm0 _ Hf_src Ht_src
-          ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc) box_dc).
+          ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)).
       { eapply coh_cmap_eval_coherent_lift_head; eauto. }
       assert (Hdecl_cur_full :
         declared_constant Σ k {| EAst.cst_body := Some body |}).
@@ -2086,7 +2077,7 @@ Section GlobalBindingsCoherence.
           + exact Hbody0. }
       assert (Hcoh_proc1 :
         @cmap_eval_coherent ((k, v) :: cm0) _ Hf_src Ht_src
-          ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc) box_dc).
+          ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)).
       { intros k1 k2 x decl1 body1 decl2 body2 src_v f t
                Hlk1 Hlk2 Hdecl1 Hbody1 Hdecl2 Hbody2 Heval1.
         simpl in Hlk1, Hlk2.
@@ -2114,13 +2105,13 @@ Section GlobalBindingsCoherence.
             - exact Hdecl2. }
           pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
                                ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)
-                               box_dc Σ_proc
+                               Σ_proc
                                [] body (fuel_sem.Val src_v) f t
                                Hwf_proc Hext_proc_small ltac:(constructor)
                                Hwf_body_proc Heval1))
             as Heval1_tail.
-          destruct (@anf_cvt_cmap_eval func_tag default_tag tgm cm0 Σ_proc box_dc
-                      box_tag Hcoh_acc
+          destruct (@anf_cvt_cmap_eval func_tag default_tag tgm cm0 Σ_proc
+                      Hcoh_acc
                       [] body src_v f t Heval1_tail
                       S0 [] S1 C v k2 decl2 body2
                       Hbody_cvt Hdis_nil Hdis_cm0 Hcons_nil Hcmap_nil
@@ -2128,7 +2119,7 @@ Section GlobalBindingsCoherence.
             as [f' [t' Heval2_tail]].
           exists f', t'. exact (@eval_env_fuel_extends _ Hf_src Ht_src
                                  ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)
-                                 box_dc Σ_proc [] body2 (fuel_sem.Val src_v) f' t'
+                                 Σ_proc [] body2 (fuel_sem.Val src_v) f' t'
                                  Hext_proc_small Heval2_tail).
         - apply eq_kername_bool_eq in Hk2. subst k2.
           injection Hlk2 as <-.
@@ -2146,7 +2137,7 @@ Section GlobalBindingsCoherence.
           { exact (wf_glob_globals_wf Σ_proc Hwf_proc _ _ _ Hdecl1_tail Hbody1). }
           pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
                                ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)
-                               box_dc Σ_proc
+                               Σ_proc
                                [] body1 (fuel_sem.Val src_v) f t
                                Hwf_proc Hext_proc_small ltac:(constructor)
                                Hwf_body1_tail Heval1))
@@ -2154,13 +2145,13 @@ Section GlobalBindingsCoherence.
           destruct (Hglob_term k {| EAst.cst_body := Some body |} body Hdecl_cur_full eq_refl)
             as [src_v_new [f_new [t_new Heval_new_full]]].
           pose proof (proj1 (@eval_env_fuel_restrict _ _ Hf_src Ht_src
-                               Σ box_dc Σ_proc
+                               Σ Σ_proc
                                [] body (fuel_sem.Val src_v_new) f_new t_new
                                Hwf_proc Hext_proc_full ltac:(constructor)
                                Hwf_body_proc Heval_new_full))
             as Heval_new_tail.
-          destruct (@anf_cvt_cmap_eval func_tag default_tag tgm cm0 Σ_proc box_dc
-                      box_tag Hcoh_acc
+          destruct (@anf_cvt_cmap_eval func_tag default_tag tgm cm0 Σ_proc
+                      Hcoh_acc
                       [] body src_v_new f_new t_new Heval_new_tail
                       S0 [] S1 C v k1 decl1 body1
                       Hbody_cvt Hdis_nil Hdis_cm0 Hcons_nil Hcmap_nil
@@ -2171,7 +2162,7 @@ Section GlobalBindingsCoherence.
           exists f_new, t_new.
           exact (@eval_env_fuel_extends _ Hf_src Ht_src
                    ((k, EAst.ConstantDecl {| EAst.cst_body := Some body |}) :: Σ_proc)
-                   box_dc Σ_proc [] body (fuel_sem.Val src_v) f_new t_new
+                   Σ_proc [] body (fuel_sem.Val src_v) f_new t_new
                    Hext_proc_small Heval_new_tail).
         - assert (Hlk1_tail : lookup_const cm0 k1 = Some x) by exact Hlk1.
           assert (Hlk2_tail : lookup_const cm0 k2 = Some x) by exact Hlk2.
@@ -2251,7 +2242,7 @@ Section GlobalBindingsCoherence.
         - exact Hbody0. }
       assert (Hcoh_proc1 :
         @cmap_eval_coherent cm0 _ Hf_src Ht_src
-          ((k, EAst.InductiveDecl ind) :: Σ_proc) box_dc).
+          ((k, EAst.InductiveDecl ind) :: Σ_proc)).
       { eapply coh_cmap_eval_coherent_lift_head; eauto. }
       eapply IHrest with (Σ_proc := (k, EAst.InductiveDecl ind) :: Σ_proc); eauto.
   Qed.
@@ -2260,7 +2251,7 @@ Section GlobalBindingsCoherence.
     forall C_env S S',
       anf_cvt_rel_global func_tag default_tag tgm
         S (List.rev Σ) [] cmap C_env S' ->
-      @cmap_eval_coherent cmap _ Hf_src Ht_src Σ box_dc.
+      @cmap_eval_coherent cmap _ Hf_src Ht_src Σ.
   Proof.
     intros C_env S S' Hcvt.
     assert (HΣ_top : Σ = List.rev (List.rev Σ) ++ []).
@@ -2275,7 +2266,7 @@ Section GlobalBindingsCoherence.
                     decl.(EAst.cst_body) = Some body).
     { intros k v Hlk. discriminate. }
 	    assert (Hcoh_empty :
-	      @cmap_eval_coherent ([] : const_map) _ Hf_src Ht_src ([] : EAst.global_context) box_dc).
+	      @cmap_eval_coherent ([] : const_map) _ Hf_src Ht_src ([] : EAst.global_context)).
 	    { intros k1 k2 x decl1 body1 decl2 body2 src_v f t Hlk1. discriminate. }
 	    assert (Hdis_empty : Disjoint _ (cmap_vars ([] : const_map)) S).
 	    { constructor. intros z Hc.
@@ -2315,17 +2306,14 @@ Section GlobalBindingsTopLevel.
     forall dc dc',
       dcon_to_tag default_tag dc tgm = dcon_to_tag default_tag dc' tgm -> dc = dc').
 
-  Context (box_dc : dcon)
-          (box_tag : dcon_to_tag default_tag box_dc tgm = default_tag).
-
   Context (cenv_case_consistent : forall P ctag, caseConsistent cenv P ctag).
-  Let Hf_src := LambdaBox_resource_fuel default_tag tgm box_dc box_tag.
-  Let Ht_src := LambdaBox_resource_trace default_tag tgm box_dc box_tag.
+  Let Hf_src := LambdaBox_resource_fuel.
+  Let Ht_src := LambdaBox_resource_trace.
 
   Let global_env_rel' :=
-    @global_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ box_dc.
+    @global_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ.
 
-  Let src_eval := @eval_env_fuel nat Hf_src Ht_src Σ box_dc.
+  Let src_eval := @eval_env_fuel nat Hf_src Ht_src Σ.
 
   Context (Hglob_term :
     forall k decl body,
@@ -2360,12 +2348,12 @@ Section GlobalBindingsTopLevel.
     forall C_env S S',
       anf_cvt_rel_global func_tag default_tag tgm
         S (List.rev Σ) [] cmap C_env S' ->
-      @cmap_eval_coherent cmap _ Hf_src Ht_src Σ box_dc.
+      @cmap_eval_coherent cmap _ Hf_src Ht_src Σ.
   Proof.
     intros C_env S S' Hcvt.
     exact (@global_ctx_cmap_eval_coherent_top_by_construction
              func_tag default_tag tgm cmap Σ efl HnoAxioms
-             box_dc box_tag Hglob_term Hglob_fuel_zero Hwf_glob
+             Hglob_term Hglob_fuel_zero Hwf_glob
              C_env S S' Hcvt).
   Qed.
 
@@ -2431,14 +2419,14 @@ Section GlobalBindingsTopLevel.
 	      inversion Hc as [? Hz _]; subst; clear Hc.
 	      destruct Hz as [k Hlk]. discriminate. }
     assert (Hcoh_empty :
-      @cmap_eval_coherent ([] : const_map) _ Hf_src Ht_src ([] : EAst.global_context) box_dc).
+      @cmap_eval_coherent ([] : const_map) _ Hf_src Ht_src ([] : EAst.global_context)).
     { intros k1 k2 x decl1 body1 decl2 body2 src_v f t Hlk1. discriminate. }
     destruct (@global_ctx_correct
                 func_tag kon_tag default_tag default_itag
                 tgm cmap cenv Σ efl
                 HnoAxioms
                 dcon_to_tag_inj
-                box_dc box_tag
+               
                 cenv_case_consistent Hcmap_eval_coherent
                 Hglob_term Hglob_fuel_zero Hglob_wf
                 prim_map prims Hwf_glob

--- a/theories/LambdaBox_to_LambdaANF/anf_toplevel.v
+++ b/theories/LambdaBox_to_LambdaANF/anf_toplevel.v
@@ -37,27 +37,24 @@ Section Refinement.
     forall dc dc',
       dcon_to_tag default_tag dc tgm = dcon_to_tag default_tag dc' tgm -> dc = dc').
 
-  Context (box_dc : dcon)
-          (box_tag : dcon_to_tag default_tag box_dc tgm = default_tag).
-
   Context (cenv_case_consistent : forall P ctag, caseConsistent cenv P ctag).
 
-  Let Hf_src := LambdaBox_resource_fuel default_tag tgm box_dc box_tag.
-  Let Ht_src := LambdaBox_resource_trace default_tag tgm box_dc box_tag.
+  Let Hf_src := LambdaBox_resource_fuel.
+  Let Ht_src := LambdaBox_resource_trace.
 
   Let anf_val_rel' :=
-    @anf_val_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ box_dc.
+    @anf_val_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ.
   Let anf_env_rel0 :=
-    @anf_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ box_dc.
+    @anf_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ.
 
   Let global_env_rel' :=
-    @global_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ box_dc.
+    @global_env_rel func_tag default_tag tgm cmap nat Hf_src Ht_src Σ.
 
-  Let src_eval := @eval_env_fuel nat Hf_src Ht_src Σ box_dc.
-  Let src_diverge := @fuel_sem.diverge nat Hf_src Ht_src Σ box_dc.
-  Let src_diverge_not_stuck := @fuel_sem.diverge_not_stuck nat Hf_src Ht_src Σ box_dc.
+  Let src_eval := @eval_env_fuel nat Hf_src Ht_src Σ.
+  Let src_diverge := @fuel_sem.diverge nat Hf_src Ht_src Σ.
+  Let src_diverge_not_stuck := @fuel_sem.diverge_not_stuck nat Hf_src Ht_src Σ.
   Let cmap_consistent' :=
-    @cmap_consistent cmap nat Hf_src Ht_src Σ box_dc.
+    @cmap_consistent cmap nat Hf_src Ht_src Σ.
 
   Lemma anf_bound_post_upper_bound f_src t_src :
     post_upper_bound (anf_bound f_src t_src).
@@ -208,12 +205,12 @@ Section Refinement.
       as Hcmap_nodup_keys.
     pose proof (@global_ctx_cmap_eval_coherent_top
                   func_tag default_tag tgm cmap Σ efl HnoAxioms
-                  box_dc box_tag Hglob_term Hglob_fuel_zero Hwf_glob
+                  Hglob_term Hglob_fuel_zero Hwf_glob
                   C_env Sg Sg' Hglob_cvt)
       as Hcmap_eval_coherent.
     pose (val_rel_exists :=
       @anf_val_rel_exists func_tag default_tag prim_map tgm prims cmap
-        _ Σ box_dc nat Hf_src Ht_src
+        _ Σ nat Hf_src Ht_src
         Hglob_term Hwf_glob
         HnoVar HnoEvar HnoCoFix HnoLazy Hblocks HnoArray
         no_prims Hcmap_complete Hcmap_sound Hcmap_nodup_keys Hcmap_eval_coherent).
@@ -222,7 +219,6 @@ Section Refinement.
                 tgm cmap cenv Σ efl
                 HnoAxioms
                 dcon_to_tag_inj
-                box_dc box_tag
                 cenv_case_consistent
                 Hglob_term Hglob_fuel_zero Hglob_wf
                 prim_map prims Hwf_glob
@@ -238,7 +234,6 @@ Section Refinement.
                   func_tag default_tag default_itag
                   tgm cmap cenv Σ efl
                   dcon_to_tag_inj
-                  box_dc box_tag
                   cenv_case_consistent Hcmap_eval_coherent
                   Hglob_term Hglob_fuel_zero Hglob_wf val_rel_exists
                   [] e (Val src_v) f t Heval)
@@ -289,7 +284,7 @@ Section Refinement.
     assert (Hctx_main0 :
       occurs_free_ctx C \subset FromList [] :|: (Sg' \\ S') :|: cmap_vars cmap).
     { exact (@anf_cvt_occurs_free_ctx_exp
-               func_tag default_tag tgm cmap Σ box_dc box_tag
+               func_tag default_tag tgm cmap Σ
                Sg' e [] S' C r Hmain_cvt Hdis_nil Hdis_main). }
     assert (Hctx_main :
       occurs_free_ctx C \subset (Sg' \\ S') :|: cmap_vars cmap).
@@ -388,12 +383,12 @@ Section Refinement.
       as Hcmap_nodup_keys.
     pose proof (@global_ctx_cmap_eval_coherent_top
                   func_tag default_tag tgm cmap Σ efl HnoAxioms
-                  box_dc box_tag Hglob_term Hglob_fuel_zero Hwf_glob
+                  Hglob_term Hglob_fuel_zero Hwf_glob
                   C_env Sg Sg' Hglob_cvt)
       as Hcmap_eval_coherent.
     pose (val_rel_exists :=
       @anf_val_rel_exists func_tag default_tag prim_map tgm prims cmap
-        _ Σ box_dc nat Hf_src Ht_src
+        _ Σ nat Hf_src Ht_src
         Hglob_term Hwf_glob
         HnoVar HnoEvar HnoCoFix HnoLazy Hblocks HnoArray
         no_prims Hcmap_complete Hcmap_sound Hcmap_nodup_keys Hcmap_eval_coherent).
@@ -401,8 +396,7 @@ Section Refinement.
                 func_tag kon_tag default_tag default_itag
                 tgm cmap cenv Σ efl
                 HnoAxioms
-                dcon_to_tag_inj
-                box_dc box_tag
+                dcon_to_tag_inj              
                 cenv_case_consistent
                 Hglob_term Hglob_fuel_zero Hglob_wf
                 prim_map prims Hwf_glob
@@ -448,8 +442,7 @@ Section Refinement.
       pose proof (@anf_cvt_correct_oot_lower_bound
                     func_tag default_tag default_itag
                     tgm cmap cenv Σ efl
-                    dcon_to_tag_inj
-                    box_dc box_tag
+                    dcon_to_tag_inj                    
                     cenv_case_consistent Hcmap_eval_coherent
                     Hglob_term Hglob_fuel_zero Hglob_wf val_rel_exists
                     [] e cin t Hoot)
@@ -471,7 +464,7 @@ Section Refinement.
     assert (Hctx_main0 :
       occurs_free_ctx C \subset FromList [] :|: (Sg' \\ S') :|: cmap_vars cmap).
     { exact (@anf_cvt_occurs_free_ctx_exp
-               func_tag default_tag tgm cmap Σ box_dc box_tag
+               func_tag default_tag tgm cmap Σ
                Sg' e [] S' C r Hmain_cvt Hdis_nil Hdis_main). }
     assert (Hctx_main :
       occurs_free_ctx C \subset (Sg' \\ S') :|: cmap_vars cmap).
@@ -537,25 +530,22 @@ Section ComputationalRefinement.
     forall dc dc',
       dcon_to_tag default_tag dc tgm = dcon_to_tag default_tag dc' tgm -> dc = dc').
 
-  Context (box_dc : dcon)
-          (box_tag : dcon_to_tag default_tag box_dc tgm = default_tag).
-
   Context (Hglob_term :
     forall k decl body,
       declared_constant Σ k decl ->
       decl.(EAst.cst_body) = Some body ->
       exists src_v f t, @eval_env_fuel nat
-        (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-        (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-        Σ box_dc [] body (Val src_v) f t).
+        LambdaBox_resource_fuel
+        LambdaBox_resource_trace
+        Σ [] body (Val src_v) f t).
   Context (Hglob_fuel_zero :
     forall k decl body src_v f t,
       declared_constant Σ k decl ->
       decl.(EAst.cst_body) = Some body ->
       @eval_env_fuel nat
-        (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-        (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-        Σ box_dc [] body (Val src_v) f t ->
+        LambdaBox_resource_fuel
+        LambdaBox_resource_trace
+        Σ [] body (Val src_v) f t ->
       f = 0).
 
   Context (Hglob_wf :
@@ -581,7 +571,7 @@ Section ComputationalRefinement.
     end.
 
   Definition refines_top (ie : ienv) (M : nat) (e_src : EAst.term) (e_tgt : exp) : Prop :=
-    refines default_tag tgm (top_cenv ie) Σ box_dc box_tag M e_src e_tgt.
+    refines default_tag tgm (top_cenv ie) Σ M e_src e_tgt.
 
   Context (ie : ienv).
   Context (cenv_case_consistent_top :
@@ -607,8 +597,7 @@ Section ComputationalRefinement.
               func_tag kon_tag default_tag default_itag
               tgm cm (top_cenv ie) Σ efl
               HnoAxioms
-              dcon_to_tag_inj
-              box_dc box_tag
+              dcon_to_tag_inj              
               cenv_case_consistent_top
               Hglob_term Hglob_fuel_zero Hglob_wf
               prim_map prims Hwf_glob
@@ -624,9 +613,9 @@ Section ComputationalRefinement.
       (fun _ => None)
       ie (List.rev Σ) e = (compM.Ret e_tgt, comp_d') ->
     @fuel_sem.diverge nat
-      (LambdaBox_resource_fuel default_tag tgm box_dc box_tag)
-      (LambdaBox_resource_trace default_tag tgm box_dc box_tag)
-      Σ box_dc [] e ->
+      LambdaBox_resource_fuel
+      LambdaBox_resource_trace
+      Σ [] e ->
     eval.diverge (top_cenv ie) (M.empty val) e_tgt.
   Proof.
     intros Hwf Hrun Hdiv.
@@ -643,7 +632,6 @@ Section ComputationalRefinement.
               tgm cm (top_cenv ie) Σ efl
               HnoAxioms
               dcon_to_tag_inj
-              box_dc box_tag
               cenv_case_consistent_top
               Hglob_term Hglob_fuel_zero Hglob_wf
               prim_map prims Hwf_glob

--- a/theories/LambdaBox_to_LambdaANF/anf_util.v
+++ b/theories/LambdaBox_to_LambdaANF/anf_util.v
@@ -29,8 +29,7 @@ Section ANF_Val.
           {Hf_src : @LambdaBox_resource nat}
           {Ht_src : @LambdaBox_resource src_trace}.
 
-  Context (Σ : EAst.global_context)
-          (box_dc : dcon).
+  Context (Σ : EAst.global_context).
 
   Let anf_cvt_rel' := anf_cvt_rel func_tag default_tag tgm cmap.
 
@@ -57,7 +56,7 @@ Section ANF_Val.
         decl.(EAst.cst_body) = Some body /\
         M.get v rho = Some anf_v /\
         (forall src_v f t,
-           @eval_env_fuel _ Hf_src Ht_src Σ box_dc [] body (fuel_sem.Val src_v) f t ->
+           @eval_env_fuel _ Hf_src Ht_src Σ [] body (fuel_sem.Val src_v) f t ->
            val_rel src_v anf_v).
 
   Inductive anf_fix_rel (fnames : list var) (names : list var)
@@ -96,7 +95,7 @@ Section ANF_Val.
       decl.(EAst.cst_body) = Some body ->
       exists v_i f t,
         nth_error rho i = Some v_i /\
-        @eval_env_fuel _ Hf_src Ht_src Σ box_dc [] body (fuel_sem.Val v_i) f t.
+        @eval_env_fuel _ Hf_src Ht_src Σ [] body (fuel_sem.Val v_i) f t.
 
   Definition cmap_eval_coherent : Prop :=
     forall k1 k2 x decl1 body1 decl2 body2 src_v f t,
@@ -106,9 +105,9 @@ Section ANF_Val.
       decl1.(EAst.cst_body) = Some body1 ->
       declared_constant Σ k2 decl2 ->
       decl2.(EAst.cst_body) = Some body2 ->
-      @eval_env_fuel _ Hf_src Ht_src Σ box_dc [] body1 (fuel_sem.Val src_v) f t ->
+      @eval_env_fuel _ Hf_src Ht_src Σ [] body1 (fuel_sem.Val src_v) f t ->
       exists f' t',
-        @eval_env_fuel _ Hf_src Ht_src Σ box_dc [] body2 (fuel_sem.Val src_v) f' t'.
+        @eval_env_fuel _ Hf_src Ht_src Σ [] body2 (fuel_sem.Val src_v) f' t'.
 
   Inductive anf_val_rel : fuel_sem.value -> val -> Prop :=
   | anf_rel_Con :
@@ -885,7 +884,7 @@ Section AlphaEquiv.
       declared_constant Σ k decl ->
       decl.(EAst.cst_body) = Some body ->
       exists src_v f t,
-        @eval_env_fuel _ Hf_src Ht_src Σ box_dc [] body (fuel_sem.Val src_v) f t).
+        @eval_env_fuel _ Hf_src Ht_src Σ [] body (fuel_sem.Val src_v) f t).
 
   Context (func_tag default_tag : positive).
 
@@ -893,7 +892,7 @@ Section AlphaEquiv.
   Let anf_cvt_rel_args' := anf_cvt_rel_args func_tag default_tag tgm cmap.
   Let anf_cvt_rel_mfix' := anf_cvt_rel_mfix func_tag default_tag tgm cmap.
   Let anf_cvt_rel_branches' := anf_cvt_rel_branches func_tag default_tag tgm cmap.
-  Let anf_val_rel' := anf_val_rel func_tag default_tag tgm cmap Σ box_dc.
+  Let anf_val_rel' := anf_val_rel func_tag default_tag tgm cmap Σ.
 
 
 (* ----------------------------------------------------------------- *)
@@ -2296,9 +2295,9 @@ Section AlphaEquiv.
           assert (Hv0_cmap : v0 \in cmap_vars cmap)
             by (exists k0; exact Hlk0).
           (* Extract from both global_env_rel' hypotheses *)
-          match goal with H : global_env_rel' _ _ _ _ _ _ |- _ =>
+          match goal with H : global_env_rel' _ _ _ _ _ |- _ =>
             pose proof (H k0 v0 Hk0 Hlk0) as Hg1_ex; clear H end.
-          match goal with H : global_env_rel' _ _ _ _ _ _ |- _ =>
+          match goal with H : global_env_rel' _ _ _ _ _ |- _ =>
             pose proof (H k0 v0 Hk0 Hlk0) as Hg2_ex; clear H end.
           destruct Hg1_ex as (decl1 & body1 & anf_v1 & Hdecl1 & Hbody1 & Hget1 & Hvrel1).
           destruct Hg2_ex as (decl2 & body2 & anf_v2 & Hdecl2 & Hbody2 & Hget2 & Hvrel2).
@@ -2346,9 +2345,9 @@ Section AlphaEquiv.
 
       (* Save hypotheses before they get confused/cleared by inv.
          Both closures share the same source, so some hyps are identical. *)
-      match goal with H : @global_env_rel' _ _ _ _ _ _ _ _ _ |- _ =>
+      match goal with H : @global_env_rel' _ _ _ _ _ _ _ _ |- _ =>
         revert H end.
-      match goal with H : @global_env_rel' _ _ _ _ _ _ _ _ _ |- _ =>
+      match goal with H : @global_env_rel' _ _ _ _ _ _ _ _ |- _ =>
         revert H end.
       (* Save Disjoint (cmap_vars cmap) S1 — both identical *)
       match goal with H : Disjoint _ (cmap_vars cmap) _ |- _ =>

--- a/theories/LambdaBox_to_LambdaANF/fuel_sem.v
+++ b/theories/LambdaBox_to_LambdaANF/fuel_sem.v
@@ -106,7 +106,6 @@ Section FUEL_SEM.
           {Ht : @LambdaBox_resource trace}.
 
   Context (Σ : EAst.global_context).
-  Context (box_dc : dcon).
 
   (** * Big-step resource semantics for EAst.term *)
 
@@ -129,12 +128,6 @@ Section FUEL_SEM.
       forall (mfix : list (EAst.def EAst.term)) (idx : nat) (rho : env),
         eval_env_step rho (EAst.tFix mfix idx)
                       (Val (ClosFix_v rho mfix idx))
-                      <0>
-                      <0>
-  | eval_Box_fuel :
-      forall (rho : env),
-        eval_env_step rho EAst.tBox
-                      (Val (Con_v box_dc []))
                       <0>
                       <0>
 
@@ -310,16 +303,7 @@ Section FUEL_SEM.
       remember (EAst.tFix mfix idx) as ea in H.
       remember (Val v2) as rv in H.
       destruct H; try discriminate.
-      injection Heqea as <- <-. injection Heqrv as <-. reflexivity.
-    (* eval_Box_fuel *)
-    - intros rho0 v2 f2 t2 Heval2.
-      remember EAst.tBox as ea in Heval2.
-      remember (Val v2) as rv in Heval2.
-      destruct Heval2; try discriminate. subst.
-      remember EAst.tBox as ea in H.
-      remember (Val v2) as rv in H.
-      destruct H; try discriminate.
-      injection Heqrv as <-. reflexivity.
+      injection Heqea as <- <-. injection Heqrv as <-. reflexivity.    
     (* eval_App_step: e1 → Clos_v *)
     - intros e1 e2 body v2' r na rho0 rho' f0 f2 f3 t0 t2 t3
              _ IH1 _ IH2 _ IH3.
@@ -498,15 +482,7 @@ Section FUEL_SEM.
             | [ Hrv : Val _ = Val _ |- _ ] => injection Hrv as <-; subst
             end.
       injection Heqea as <- <-. subst.
-      split; [reflexivity | split; reflexivity].
-    - intros rho0 v2 f2 t2 Heval2.
-      remember EAst.tBox as ea in Heval2.
-      remember (Val v2) as rv in Heval2.
-      destruct Heval2; try discriminate;
-        try match goal with
-            | [ Hrv : Val _ = Val _ |- _ ] => injection Hrv as <-; subst
-            end.
-      split; [reflexivity | split; reflexivity].
+      split; [reflexivity | split; reflexivity].    
     - intros e1 e2 body v2' r na rho0 rho' f0 f2 t0 t2 f3 t3
              _ IH1 _ IH2 _ IH3.
       destruct r as [v_r |]; [| exact I].

--- a/theories/LambdaBox_to_LambdaANF/wf.v
+++ b/theories/LambdaBox_to_LambdaANF/wf.v
@@ -212,7 +212,6 @@ Section WF_EVAL.
           {Hf : @LambdaBox_resource nat}
           {Ht : @LambdaBox_resource trace}.
   Context (Σ : EAst.global_context).
-  Context (box_dc : dcon).
 
   Hypothesis globals_wellformed :
     forall k decl body,
@@ -223,7 +222,7 @@ Section WF_EVAL.
   Lemma eval_preserves_wf rho e v f t :
     well_formed_env Σ rho ->
     wellformed Σ (List.length rho) e = true ->
-    eval_env_fuel Σ box_dc rho e (Val v) f t ->
+    eval_env_fuel Σ rho e (Val v) f t ->
     well_formed_val Σ v.
   Proof.
     intros Hwf_env Hwf_e Heval.
@@ -237,7 +236,7 @@ Section WF_EVAL.
       Forall (fun e => wellformed Σ (List.length rho) e = true) es ->
       Forall (well_formed_val Σ) vs).
     enough (Haux : Pwf rho e (Val v) f t) by exact (Haux Hwf_env Hwf_e).
-    apply (eval_env_fuel_ind' Σ box_dc Pwf Pmany Pwf); try exact Heval;
+    apply (eval_env_fuel_ind' Σ Pwf Pmany Pwf); try exact Heval;
     unfold Pwf, Pmany; try solve [intros; exact I].
     (* eval_Rel_fuel *)
     - intros n rho0 v0 Hnth Hwfe Hwft.
@@ -253,8 +252,6 @@ Section WF_EVAL.
     - intros mfix idx rho0 Hwfe Hwft.
       apply wellformed_tFix in Hwft as [Hidx Hwf_mfix].
       apply Wf_ClosFix; assumption.
-    (* eval_Box_fuel *)
-    - intros rho0 _ _. constructor. constructor.
     (* eval_App_step: e1 → Clos_v *)
     - intros e1 e2 body v2 r na rho0 rho' f1 f2 f3 t1 t2 t3
              _ IH1 _ IH2 _ IH3 Hwfe Hwft.
@@ -375,7 +372,7 @@ Section WF_EVAL.
     EGlobalEnv.extends Σ_tail Σ ->
     well_formed_env Σ_tail rho ->
     wellformed Σ_tail (List.length rho) e = true ->
-    eval_env_fuel Σ box_dc rho e (Val v) f t ->
+    eval_env_fuel Σ rho e (Val v) f t ->
     well_formed_val Σ_tail v.
   Proof.
     intros Hwf_tail Hext.
@@ -393,7 +390,7 @@ Section WF_EVAL.
       Forall (fun e => wellformed Σ_tail (List.length rho) e = true) es ->
       Forall (well_formed_val Σ_tail) vs).
     enough (Haux : Pwf rho e (Val v) f t) by exact (Haux Hwf_env Hwf_e).
-    apply (eval_env_fuel_ind' Σ box_dc Pwf Pmany Pwf); try exact Heval;
+    apply (eval_env_fuel_ind' Σ Pwf Pmany Pwf); try exact Heval;
     unfold Pwf, Pmany; try solve [intros; exact I].
     (* eval_Rel_fuel *)
     - intros n rho0 v0 Hnth Hwfe Hwft.
@@ -409,8 +406,6 @@ Section WF_EVAL.
     - intros mfix idx rho0 Hwfe Hwft.
       apply (wellformed_tFix Σ_tail) in Hwft as [Hidx Hwf_mfix].
       apply (Wf_ClosFix Σ_tail); assumption.
-    (* eval_Box_fuel *)
-    - intros rho0 _ _. constructor. constructor.
     (* eval_App_step: e1 → Clos_v *)
     - intros e1 e2 body v2 r na rho0 rho' f1 f2 f3 t1 t2 t3
              _ IH1 _ IH2 _ IH3 Hwfe Hwft.
@@ -511,7 +506,7 @@ Section EVAL_RESTRICT.
   Context {trace : Type}
           {Hf : @LambdaBox_resource nat}
           {Ht : @LambdaBox_resource trace}.
-  Context (Σ : EAst.global_context) (box_dc : dcon).
+  Context (Σ : EAst.global_context).
 
   (** If a term is wellformed w.r.t. Σ_tail and evaluates under Σ,
       then it evaluates identically under Σ_tail (same result, fuel, trace).
@@ -522,8 +517,8 @@ Section EVAL_RESTRICT.
     EGlobalEnv.extends Σ_tail Σ ->
     well_formed_env Σ_tail rho ->
     wellformed Σ_tail (List.length rho) e = true ->
-    @eval_env_fuel trace Hf Ht Σ box_dc rho e r f t ->
-    @eval_env_fuel trace Hf Ht Σ_tail box_dc rho e r f t /\
+    @eval_env_fuel trace Hf Ht Σ rho e r f t ->
+    @eval_env_fuel trace Hf Ht Σ_tail rho e r f t /\
     match r with Val v => well_formed_val Σ_tail v | OOT => True end.
   Proof.
     intros Hwf_tail Hext.
@@ -533,22 +528,22 @@ Section EVAL_RESTRICT.
                       (r : fuel_sem.result) (f : nat) (t : trace) =>
       well_formed_env Σ_tail rho ->
       wellformed Σ_tail (List.length rho) e = true ->
-      @fuel_sem.eval_env_step trace Hf Ht Σ_tail box_dc rho e r f t /\
+      @fuel_sem.eval_env_step trace Hf Ht Σ_tail rho e r f t /\
       match r with fuel_sem.Val v => well_formed_val Σ_tail v | fuel_sem.OOT => True end).
     set (Pmany := fun (rho : fuel_sem.env) (es : list EAst.term)
                       (vs : list fuel_sem.value) (fs : nat) (ts : trace) =>
       well_formed_env Σ_tail rho ->
       Forall (fun e => wellformed Σ_tail (List.length rho) e = true) es ->
-      @fuel_sem.eval_fuel_many trace Hf Ht Σ_tail box_dc rho es vs fs ts /\
+      @fuel_sem.eval_fuel_many trace Hf Ht Σ_tail rho es vs fs ts /\
       Forall (well_formed_val Σ_tail) vs).
     set (Pfuel := fun (rho : fuel_sem.env) (e : EAst.term)
                       (r : fuel_sem.result) (f : nat) (t : trace) =>
       well_formed_env Σ_tail rho ->
       wellformed Σ_tail (List.length rho) e = true ->
-      @eval_env_fuel trace Hf Ht Σ_tail box_dc rho e r f t /\
+      @eval_env_fuel trace Hf Ht Σ_tail rho e r f t /\
       match r with fuel_sem.Val v => well_formed_val Σ_tail v | fuel_sem.OOT => True end).
     enough (Haux : Pfuel rho e r f t) by exact (Haux Hwf_env Hwf_e).
-    apply (@fuel_sem.eval_env_fuel_ind' trace Hf Ht Σ box_dc Pstep Pmany Pfuel);
+    apply (@fuel_sem.eval_env_fuel_ind' trace Hf Ht Σ Pstep Pmany Pfuel);
       try exact Heval;
     unfold Pstep, Pmany, Pfuel; try solve [intros; exact I].
     (* eval_Rel_fuel *)
@@ -567,10 +562,6 @@ Section EVAL_RESTRICT.
       + eapply fuel_sem.eval_Fix_fuel.
       + apply (wellformed_tFix Σ_tail) in Hwft as [Hidx Hwf_mfix].
         apply (Wf_ClosFix Σ_tail); assumption.
-    (* eval_Box_fuel *)
-    - intros rho0 _ _. split.
-      + eapply fuel_sem.eval_Box_fuel.
-      + constructor. constructor.
     (* eval_App_step: e1 → Clos_v *)
     - intros e1 e2 body v2 r0 na rho0 rho' f1 f2 f3 t1 t2 t3
              _ IH1 _ IH2 _ IH3 Hwfe Hwft.
@@ -729,26 +720,25 @@ Section EVAL_RESTRICT.
       Doesn't need well-formedness. *)
   Lemma eval_env_fuel_extends Σ_tail rho e r f t :
     EGlobalEnv.extends Σ_tail Σ ->
-    @eval_env_fuel trace Hf Ht Σ_tail box_dc rho e r f t ->
-    @eval_env_fuel trace Hf Ht Σ box_dc rho e r f t.
+    @eval_env_fuel trace Hf Ht Σ_tail rho e r f t ->
+    @eval_env_fuel trace Hf Ht Σ rho e r f t.
   Proof.
     intros Hext Heval.
     set (Pstep := fun (rho : fuel_sem.env) (e : EAst.term)
                       (r : fuel_sem.result) (f : nat) (t : trace) =>
-      @fuel_sem.eval_env_step trace Hf Ht Σ box_dc rho e r f t).
+      @fuel_sem.eval_env_step trace Hf Ht Σ rho e r f t).
     set (Pmany := fun (rho : fuel_sem.env) (es : list EAst.term)
                       (vs : list fuel_sem.value) (fs : nat) (ts : trace) =>
-      @fuel_sem.eval_fuel_many trace Hf Ht Σ box_dc rho es vs fs ts).
+      @fuel_sem.eval_fuel_many trace Hf Ht Σ rho es vs fs ts).
     set (Pfuel := fun (rho : fuel_sem.env) (e : EAst.term)
                       (r : fuel_sem.result) (f : nat) (t : trace) =>
-      @eval_env_fuel trace Hf Ht Σ box_dc rho e r f t).
+      @eval_env_fuel trace Hf Ht Σ rho e r f t).
     enough (Haux : Pfuel rho e r f t) by exact Haux.
-    apply (@fuel_sem.eval_env_fuel_ind' trace Hf Ht Σ_tail box_dc Pstep Pmany Pfuel);
+    apply (@fuel_sem.eval_env_fuel_ind' trace Hf Ht Σ_tail Pstep Pmany Pfuel);
       try exact Heval; unfold Pstep, Pmany, Pfuel; intros.
     - eapply fuel_sem.eval_Rel_fuel; eassumption.
     - eapply fuel_sem.eval_Lam_fuel.
     - eapply fuel_sem.eval_Fix_fuel.
-    - eapply fuel_sem.eval_Box_fuel.
     - eapply fuel_sem.eval_App_step; eassumption.
     - eapply fuel_sem.eval_App_step_OOT1; eassumption.
     - eapply fuel_sem.eval_App_step_OOT2; eassumption.


### PR DESCRIPTION
No need to map box to a constructor anymore, there are no boxes left (they're all `let rec f x = f`).
This also simplifies the side conditions of the main theorem which was relying on a special invariant for the constructor tag associated to box. 