### PR TITLE
opam: use rocq-* packages and relax exact version pins

### DIFF
--- a/rocq-certirocq.opam
+++ b/rocq-certirocq.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "dev+9.0"
+version: "dev"
 maintainer: "The CertiRocq Team"
 homepage: "https://certirocq.org/"
 dev-repo: "git+https://github.com/CertiRocq/certirocq"
@@ -30,17 +30,22 @@ install: [
 depends: [
   "ocaml" {>= "4.13"}
   "conf-clang"
+  # "make plugins" runs plugins/manifests/generate.py
+  "conf-python-3" {build}
   "stdlib-shims"
-  "coq" {>= "9.1" & < "9.2~"}
-  "coq-compcert" {= "3.17"}
-  "rocq-equations" {= "1.3.1+9.1"}
+  "rocq-core" {>= "9.1"}
+  "rocq-stdlib" {>= "9.1"}
+  # coq-core provides the coq_makefile binary that the Makefiles invoke
+  "coq-core" {>= "9.1"}
+  "coq-compcert" {>= "3.17"}
+  "rocq-equations" {>= "1.3.1+9.1"}
   "rocq-metarocq-erasure-plugin" {>= "1.5.1"}
   "rocq-metarocq-safechecker-plugin" {>= "1.5.1"}
   "coq-ext-lib" {>= "0.12"}
-  "coq-wasm" {= "2.2.0"}
+  "coq-wasm" {>= "2.2.0"}
 ]
 
 synopsis: "A Verified Compiler for Gallina, Written in Gallina "
 url {
-  git: "https://github.com/CertiRocq/certirocq.git"
+  src: "git+https://github.com/CertiRocq/certirocq.git"
 }


### PR DESCRIPTION
**Draft**: the dependency edits are all justified below, but I have not been able to complete an
end-to-end build of `main` (see *What I could not verify*), so please treat the bounds as proposals.

### Problem

`rocq-certirocq.opam` on `main` still constrains the prover to Coq/Rocq 9.1 only, and pins three
dependencies with `=`. Following `INSTALL.md` (`opam pin -n .` then `opam install rocq-certirocq`)
on a switch with a newer Rocq gives:

```
[ERROR] Package conflict!
  * Missing dependency:
    - rocq-certirocq >= dev+9.0 → coq < 9.2~
    not available because the package is pinned to version dev

No solution found, exiting
```

and, one at a time, the other three exact pins fail the same way against dev packages:

```
[ERROR] coq-compcert = 3.17: not available because the package is pinned to version dev
[ERROR] rocq-equations = 1.3.1+9.1: not available because the package is pinned to version dev
[ERROR] coq-wasm = 2.2.0: not available because the package is pinned to version dev
```

(`rocq-metarocq-*-plugin {>= "1.5.1"}` and `coq-ext-lib {>= "0.12"}` are already fine — a `dev`
version satisfies a `>=` numeric bound.)

### Changes

* **`"coq" {>= "9.1" & < "9.2~"}` → `rocq-core` + `rocq-stdlib` + `coq-core`.**
  `main` uses `From Stdlib Require` (220 occurrences under `theories/`, `libraries/`, `plugins/`,
  `bootstrap/`) plus 8 `From Corelib Require`, so `rocq-stdlib` is a real dependency and not implied by
  `rocq-core`. `coq-core` is deliberately kept: `Makefile`, `libraries/Makefile` and both plugin
  Makefiles call `coq_makefile`, and on a 9.x switch `bin/coq_makefile` is installed by `coq-core`,
  not by `rocq-core`. If you would rather drop the `coq-core` dependency, the Makefiles need to move
  to `rocq makefile` first (the `master`/`coq-9.1` branches already did part of this for the test
  Makefiles in "Use rocq c across test makefiles").
  The upper bound is dropped because `main` is the development branch — `master`/`coq-9.1` keep the
  bounded version.

* **`coq-compcert`, `rocq-equations`, `coq-wasm`: `=` → `>=`.** Exact pins make the package
  unsolvable against any `.dev` pin of those packages and against future releases.

* **New: `"conf-python-3" {build}`.** `make plugins` (in the `build:` list) runs
  `$(PYTHON) plugins/manifests/generate.py`. The generated `plugins/*/​_CoqProject` and
  `plugins/*/*.mlpack` are checked in, but the make rule lists `theories/Extraction/extraction.vo`
  as a prerequisite, and that is always rebuilt from scratch in an opam build, so the rule always
  fires and `python3` is genuinely required at build time.

* **`version: "dev+9.0"` → `"dev"`.** It named 9.0 while the dependencies already required 9.1.
  This is the one edit that is a judgement call — say the word and I will restore it or use
  `dev+9.1` instead.

* **`url { git: ... }` → `url { src: "git+..." }`.** `git:` is opam 1.2 syntax.

`opam lint` passes under both opam 2.1.2 and 2.5.1.

### What I could not verify

I tried to build `main` against a Rocq dev switch (Rocq 9.4+alpha) and could not get a clean build,
but neither blocker looks like a CertiRocq bug and neither is addressed by this PR:

1. That switch's MetaRocq is `9242c14` (2026-07-15). At that commit `MetaRocq.Common.Universes`
   declares `Monomorphic_entry` with no argument, so
   `theories/LambdaANF/PrototypeGenFrame.v:610,686` fail with
   `Illegal application (Non-functional construction)`. MetaRocq `main` as of `e8bb91d` (2026-07-29)
   declares `Monomorphic_entry (ctx : ContextSet.t)` again, so this is a stale checkout on my side,
   not a source problem here.
2. The same checkout has no `erasure/theories/EImplementLazyForce.v`, so
   `theories/Compiler/metarocq_pipeline.v:19` fails with
   `Unable to locate library EImplementLazyForce with prefix MetaRocq.Erasure`. That file is present on
   MetaRocq `main` today. Worth noting: it is *not* present at the `v1.5.1-9.2` tag either, so the
   `{>= "1.5.1"}` bound on `rocq-metarocq-erasure-plugin` is arguably too weak — a released
   MetaRocq 1.5.1 cannot build `main`. I left that bound alone here because I do not know which
   MetaRocq release you intend to target; a companion `.dev` package I am proposing for the Rocq opam
   archive pins it to `dev` for that reason.

Two other things I noticed while doing this, both out of scope:

* `coq-compcert` and `coq-compcert-64` are different packages with different install layouts
  (`user-contrib/compcert` vs `lib/coq-variant/compcert64/compcert`); CertiRocq needs the former, which
  is what this file asks for, but it is easy to end up with the latter on a switch shared with VST.
* `coq-wasm.dev` installs a partial `compcert` tree into `user-contrib/compcert` (`Archi`,
  `lib/{Coqlib,Floats,IEEE754_extra,Integers,Zbits}`, `common/Memdata`), which collides with a real
  `coq-compcert` installation — and CertiRocq depends on both.
