### PR TITLE
Build against a current Rocq dev switch

### DIFF
--- a/bootstrap/certirocqc/Makefile
+++ b/bootstrap/certirocqc/Makefile
@@ -102,6 +102,7 @@ theories/CertiRocqC.vo: theories/CertiRocqC.v $(CERTIROCQ_PIPELINE_DEPS)
 theories/compile.v: theories/CertiRocqC.vo
 
 theories/compile.vo CertiRocq.CertiRocqC.compile.certirocqc.c &: theories/compile.v theories/CertiRocqC.vo $(CERTIROCQ_PIPELINE_DEPS)
+	ulimit -Ss unlimited 2>/dev/null || ulimit -Ss "$$(ulimit -Hs)" 2>/dev/null || true; \
 	coqc $(COQOPTS) $<
 
 g_certirocqc.ml: g_certirocqc.mlg certirocqc.cmx certirocqc_plugin_wrapper.cmx

--- a/bootstrap/certirocqc/g_certirocqc.mlg
+++ b/bootstrap/certirocqc/g_certirocqc.mlg
@@ -87,6 +87,6 @@ TACTIC EXTEND CertiRocqc_eval
       let opts = Certirocq.make_options l [] "goal" in
       let opts = Certirocq.{ opts with toplevel_name = "goal" } in
       let c' = Certirocq.eval ~opaque_access:Library.indirect_accessor opts env sigma c [] in
-      ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c'])
+      Tacinterp.Value.apply tac (List.map to_ltac_val [EConstr.of_constr c'])
   end }
 END

--- a/plugins/common/certirocq_commands.mlg
+++ b/plugins/common/certirocq_commands.mlg
@@ -17,28 +17,6 @@ open Stdarg
 open Tacarg
 open Genredexpr
 
-(** Calling Ltac **)
-
-let ltac_lcall tac args =
-  let (location, name) = Loc.tag (Names.Id.of_string tac)
-    (* Loc.tag @@ Names.Id.of_string tac *)
-  in
-  CAst.make ?loc:location (Tacexpr.TacArg(Tacexpr.TacCall
-                              (CAst.make (Locus.ArgVar (CAst.make ?loc:location name),args))))
-
-
-let ltac_apply (f : Value.t) (args: Tacinterp.Value.t list) =
-  let fold arg (i, vars, lfun) =
-    let id = Names.Id.of_string ("x" ^ string_of_int i) in
-    let (l,n) = (Loc.tag id) in
-    let x = Reference (Locus.ArgVar (CAst.make ?loc:l n)) in
-    (succ i, x :: vars, Id.Map.add id arg lfun)
-  in
-  let (_, args, lfun) = List.fold_right fold args (0, [], Id.Map.empty) in
-  let lfun = Id.Map.add (Id.of_string "F") f lfun in
-  let ist = { (Tacinterp.default_ist ()) with Tacinterp.lfun = lfun; } in
-  Tacinterp.eval_tactic_ist ist (ltac_lcall "F" args)
-
 let to_ltac_val c = Tacinterp.Value.of_constr c
 
 let globref_of_qualid ?loc (gr : Libnames.qualid) : Names.GlobRef.t  =
@@ -241,6 +219,6 @@ TACTIC EXTEND CertiRocq_eval
       let opts = Certirocq.make_options l [] goal in
       let opts = Certirocq_options.{ opts with toplevel_name = goal } in
       let c_eval = Certirocq.eval ~opaque_access:Library.indirect_accessor opts env sigma c [] in
-      ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c_eval])
+      Tacinterp.Value.apply tac (List.map to_ltac_val [EConstr.of_constr c_eval])
   end }
 END

--- a/theories/CodegenWasm/LambdaANF_to_Wasm_instantiation.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_instantiation.v
@@ -211,7 +211,7 @@ Proof.
       end) as f.
     have Hindep := nth_indep _ _ (f def).
     rewrite Hindep; try lia.
-       cbn. subst f. rewrite map_nth.
+       cbn. subst f. rewrite List.map_nth.
     rewrite IHm; auto.
 Qed.
 

--- a/theories/CodegenWasm/LambdaANF_to_Wasm_primitives_correct.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_primitives_correct.v
@@ -22,7 +22,7 @@ From compcert Require Import
   Coqlib common.Memory.
 
 From Wasm Require Import
-  datatypes operations host memory_list opsem
+  datatypes operations host opsem
   type_preservation properties common numerics.
 
 Import ssreflect eqtype ssrbool eqtype.
@@ -2311,7 +2311,7 @@ Proof.
       unfold Int64.isub, Int64.sub. replace (Int64.unsigned (Int64.repr 1)) with 1%Z by now cbn.
       rewrite Heq0. replace (Int64.clz (Int64.repr (to_Z 0))) with (Int64.repr 64). simpl.
       replace (Int64.repr 63) with (Int64.repr (to_Z (head0 0))). reflexivity.
-      rewrite head00_spec. unfold digits. reflexivity. reflexivity.
+      rewrite (head00_spec 0). unfold digits. reflexivity. reflexivity.
       rewrite to_Z_0. unfold Int64.clz. reflexivity. apply to_Z_inj in Heq0. rewrite Heq0.
       apply rt_refl.
       dostep_nary 2. apply r_simple. apply rs_binop_success; first done. simpl.
@@ -5016,10 +5016,10 @@ Proof.
       destruct (Z_le_dec (to_Z n1) 63) as [Hle | Hgt].
       { have Hn1bounded := to_Z_bounded n1.
         assert (0 <= to_Z 63 - to_Z n1 <= 63)%Z. replace (to_Z 63) with 63%Z by now cbn. split. lia. lia.
-        assert ((to_Z n1) mod Int64.wordsize = to_Z n1)%Z.
-        rewrite Z.mod_small. reflexivity. unfold Int64.wordsize, Integers.Wordsize_64.wordsize. lia.
-        assert (((to_Z 63) - (to_Z n1)) mod Int64.wordsize = 63 - (to_Z n1))%Z.
-        rewrite Z.mod_small. reflexivity. unfold Int64.wordsize, Integers.Wordsize_64.wordsize. lia.
+        assert ((to_Z n1) mod 64 = to_Z n1)%Z.
+        rewrite Z.mod_small. reflexivity. lia.
+        assert (((to_Z 63) - (to_Z n1)) mod 64 = 63 - (to_Z n1))%Z.
+        rewrite Z.mod_small. reflexivity. lia.
         assert (Int64.unsigned (Int64.repr ((to_Z 63) - (to_Z n1))) = (to_Z 63) - (to_Z n1))%Z.
         cbn. rewrite Int64.Z_mod_modulus_id. reflexivity. rewrite int64_modulus_eq_pow64. lia.
         have Hn3bounded := to_Z_bounded n3. unfold wB in Hn3bounded. cbn in Hn3bounded.
@@ -5063,10 +5063,12 @@ Proof.
         rewrite uint63_unsigned_id. rewrite uint63_unsigned_id. reflexivity.
         dostep_nary_eliml 2 1. apply r_simple. apply rs_binop_success; first done.
         simpl. unfold Int64.ishr_u. unfold Int64.shru.
+        rewrite int64_modu_iwordsize.
         rewrite H6. rewrite H5. rewrite H6. rewrite uint63_unsigned_id.
         rewrite Z.shiftr_div_pow2. reflexivity. lia.
         dostep_nary' 2. apply r_simple. apply rs_binop_success; first done. cbn.
-        unfold Int64.ishl. rewrite uint63_unsigned_id. rewrite H4.
+        unfold Int64.ishl. rewrite int64_modu_iwordsize.
+        rewrite uint63_unsigned_id. rewrite H4.
         unfold Int64.ior. rewrite Int64.shifted_or_is_add.
         reflexivity. unfold Int64.zwordsize. unfold Int64.wordsize, Integers.Wordsize_64.wordsize. lia.
         rewrite two_p_equiv.

--- a/theories/CodegenWasm/LambdaANF_to_Wasm_primitives_correct.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_primitives_correct.v
@@ -2967,17 +2967,17 @@ Proof.
     rewrite Haddr1 in Hload1'.
     rewrite H4 in Hload2'.
     replace 8 with (N.to_nat (tnum_length T_i64)) in Hload1', Hload2' by now cbn.
-    assert (Hbsx : wasm_deserialise b0 T_i64 = Z_to_VAL_i64 φ (n1)%uint63) by congruence.
-    assert (Hbsy : wasm_deserialise b1 T_i64 = Z_to_VAL_i64 φ (n2)%uint63) by congruence.
+    assert (Hbsx : wasm_deserialise b0 T_i64 = Z_to_VAL_i64 (to_Z n1)) by congruence.
+    assert (Hbsy : wasm_deserialise b1 T_i64 = Z_to_VAL_i64 (to_Z n2)) by congruence.
     assert (HgmpBounds: (Z.of_N gmp_v + Z.of_N 52 <= Z.of_N (mem_length m) < Int32.modulus)%Z). {
       apply mem_length_upper_bound in Hmem5. cbn in Hmem5.
       simpl_modulus. cbn. cbn in HenoughM. lia. }
     remember {|f_locs := set_nth (VAL_num (VAL_int32 (wasm_value_to_i32 (Val_ptr (gmp_v + 8)%N)))) (f_locs f) (N.to_nat x0') (VAL_num (VAL_int32 (wasm_value_to_i32 (Val_ptr (gmp_v + 8)%N))));
                f_inst := f_inst f|} as fr_carry_ops.
 
-    assert (local_holds_address_to_i64 s f x' (N_to_i32 addr1) (Z_to_i64 φ (n1)%uint63) m b0) as Hlocalx.
+    assert (local_holds_address_to_i64 s f x' (N_to_i32 addr1) (Z_to_i64 (to_Z n1)) m b0) as Hlocalx.
     by unfold local_holds_address_to_i64; auto.
-    assert (local_holds_address_to_i64 s f y' (N_to_i32 addr2) (Z_to_i64 φ (n2)%uint63) m b1) as Hlocaly.
+    assert (local_holds_address_to_i64 s f y' (N_to_i32 addr2) (Z_to_i64 (to_Z n2)) m b1) as Hlocaly.
     by unfold local_holds_address_to_i64; auto.
 
     rewrite Hvs in Hres.

--- a/theories/CodegenWasm/LambdaANF_to_Wasm_utils.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_utils.v
@@ -1030,7 +1030,7 @@ Proof.
   unfold store, write_bytes_meminst. intros.
   destruct ((n + off + N.of_nat (Datatypes.length bs) <=? mem_length m)%N) eqn:Hlen=>//.
   destruct (write_bytes _ _ _) eqn:Hb=>//. inv H.
-  apply write_bytes_preserve_length in Hb.
+  apply write_bytes_gen_preserve_length in Hb.
   unfold mem_length.
   now rewrite Hb.
 Qed.

--- a/theories/CodegenWasm/LambdaANF_to_Wasm_utils.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_utils.v
@@ -1133,7 +1133,7 @@ Proof.
   destruct (addr + 0 + N.of_nat 4 <=? mem_length m)%N eqn:Hlen=>//.
   destruct (write_bytes _ _ _) eqn:Hby=>//. inv H0.
   unfold load. cbn.
-  have Hlen' := (write_bytes_preserve_length Hby). unfold mem_length in *. cbn.
+  have Hlen' := (write_bytes_gen_preserve_length Hby). unfold mem_length in *. cbn.
   destruct (addr + 4 <=? memory.mem_length m0)%N eqn:Hlen''; try lia.
   cbn.
   now erewrite write_bytes_read_bytes_i32.
@@ -1200,7 +1200,7 @@ Proof.
   destruct (addr + 0 + N.of_nat 8 <=? mem_length m)%N eqn:Hlen=>//.
   destruct (write_bytes _ _ _) eqn:Hby=>//. inv H0.
   unfold load. cbn.
-  have Hlen' := (write_bytes_preserve_length Hby). unfold mem_length in *. cbn.
+  have Hlen' := (write_bytes_gen_preserve_length Hby). unfold mem_length in *. cbn.
   destruct (addr + 8 <=? memory.mem_length m0)%N eqn:Hlen''; try lia.
   now erewrite write_bytes_read_bytes_i64.
 Qed.
@@ -1387,7 +1387,7 @@ Proof.
   destruct (a1 + (0 + 4) <=? mem_length m)%N eqn:Hlen'=>//.
   destruct (read_bytes _ _ _) eqn:Hread=>//.
   destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv H2. inv H1.
-  have Hlen'' := write_bytes_preserve_length Hwrite.
+  have Hlen'' := write_bytes_gen_preserve_length Hwrite.
   unfold mem_length. cbn. rewrite -Hlen'' Hlen'.
   unfold read_bytes, those in *. cbn. rewrite -!N.add_assoc. cbn.
   cbn in Hread. rewrite -!N.add_assoc in Hread. cbn in Hread.
@@ -1435,7 +1435,7 @@ Proof.
   destruct (a1 + (0 + 4) <=? mem_length m)%N eqn:Hlen'=>//.
   destruct (read_bytes _ _ _) eqn:Hread=>//.
   destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv H2. inv H1.
-  have Hlen'' := write_bytes_preserve_length Hwrite.
+  have Hlen'' := write_bytes_gen_preserve_length Hwrite.
   unfold mem_length. cbn. rewrite -Hlen'' Hlen'.
   unfold read_bytes, those in *. cbn. rewrite -!N.add_assoc. cbn.
   cbn in Hread. rewrite -!N.add_assoc in Hread. cbn in Hread.
@@ -1480,7 +1480,7 @@ Proof.
   destruct (a1 + (0 + 8) <=? mem_length m)%N eqn:Hlen'=>//.
   destruct (read_bytes _ _ _) eqn:Hread=>//.
   destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv H2. inv H1.
-  have Hlen'' := write_bytes_preserve_length Hwrite.
+  have Hlen'' := write_bytes_gen_preserve_length Hwrite.
   unfold mem_length. cbn. rewrite -Hlen'' Hlen'.
   unfold read_bytes, those in *. cbn. rewrite -!N.add_assoc. cbn.
   cbn in Hread. rewrite -!N.add_assoc in Hread. cbn in Hread.
@@ -1532,7 +1532,7 @@ Proof.
   destruct (a1 + (0 + 8) <=? mem_length m)%N eqn:Hlen'=>//.
   destruct (read_bytes _ _ _) eqn:Hread=>//.
   destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv H2. inv H1.
-  have Hlen'' := write_bytes_preserve_length Hwrite.
+  have Hlen'' := write_bytes_gen_preserve_length Hwrite.
   unfold mem_length. cbn. rewrite -Hlen'' Hlen'.
   unfold read_bytes, those in *. cbn. rewrite -!N.add_assoc. cbn.
   cbn in Hread. rewrite -!N.add_assoc in Hread. cbn in Hread.

--- a/theories/CodegenWasm/LambdaANF_to_Wasm_utils.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_utils.v
@@ -1039,22 +1039,18 @@ Lemma enough_space_to_store m k off bs :
   (k + off + N.of_nat (length bs) <= mem_length m)%N ->
   store m k off bs (length bs) <> None.
 Proof.
-  intros. unfold store, write_bytes_meminst, bytes_takefill.
-  apply N.leb_le in H. rewrite H.
-  intro Hcontra.
-  destruct (write_bytes _ _ _) eqn:Hby=>//. clear Hcontra.
-  destruct (length bs <? length bs) eqn:Hcontra; first lia. clear Hcontra.
-  generalize dependent k. revert off m.
-  induction bs; intros=>//.
-  cbn in Hby, H.
-  destruct (mem_update _ _ _) eqn:Hupd.
-  2:{ eapply mem_update_ib; eauto. unfold mem_length in H. lia. }
-  assert ((k + (N.succ off) + N.of_nat (Datatypes.length bs) <=? mem_length m)%N = true)
-      as Hlen by lia.
-  clear H.
-  eapply (IHbs _ (Build_meminst (meminst_type m) m0)); last eassumption.
-  apply mem_update_length in Hupd.
-  unfold mem_length in *. rewrite Hupd. lia.
+  intros H. unfold store.
+  assert ((k + off + N.of_nat (length bs) <=? mem_length m)%N = true) as Hleb
+      by now apply N.leb_le.
+  rewrite Hleb.
+  assert (bytes_takefill #00 (length bs) bs = bs) as Hfill.
+  { unfold bytes_takefill. rewrite Nat.ltb_irrefl. apply List.firstn_all. }
+  rewrite Hfill.
+  unfold write_bytes_meminst, write_bytes.
+  destruct (write_bytes_gen _ _ _ _) eqn:Hby=>//.
+  exfalso. revert Hby. unfold write_bytes_gen.
+  apply mem_update_gen_ib.
+  unfold mem_length in H. exact H.
 Qed.
 
 Definition load_i32 m addr : option value_num :=

--- a/theories/CodegenWasm/LambdaANF_to_Wasm_utils.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_utils.v
@@ -1094,34 +1094,74 @@ Definition wasm_value_to_i32 (v : wasm_value) :=
 (* memory TODO cleanup/automate *)
 
 
+Lemma nth_error_iota : forall len m n,
+  Nat.lt n len -> List.nth_error (iota m len) n = Some (Nat.add m n).
+Proof.
+  induction len; intros m n Hlt; first lia.
+  destruct n; cbn.
+  - by rewrite Nat.add_0_r.
+  - rewrite IHlen; last lia. f_equal. lia.
+Qed.
+
+Lemma write_bytes_read_bytes : forall mt md addr bs m0,
+  write_bytes md addr bs = Some m0 ->
+  read_bytes {| meminst_type := mt; meminst_data := m0 |} addr (length bs) = Some bs.
+Proof.
+  intros mt md addr bs m0 Hw.
+  unfold read_bytes. cbn.
+  apply those_spec.
+  { rewrite length_map. apply (size_iota 0 (length bs)). }
+  intros n x Hnth.
+  assert (Nat.lt n (length bs)) as Hlt by (apply nth_error_Some; congruence).
+  erewrite map_nth_error; last first.
+  { apply nth_error_iota. exact Hlt. }
+  cbn. do 2 f_equal.
+  unfold write_bytes, write_bytes_gen in Hw.
+  erewrite mem_update_gen_lookup; [ | exact Hw | lia ].
+  unfold lookup_N. rewrite Nnat.Nat2N.id. by rewrite Hnth.
+Qed.
+
+Lemma bytes_takefill_id : forall n bs, length bs = n -> bytes_takefill #00 n bs = bs.
+Proof.
+  intros n bs Hlen. unfold bytes_takefill.
+  rewrite Hlen Nat.ltb_irrefl -Hlen. apply List.firstn_all.
+Qed.
+
+Lemma in_iota_lt : forall len m n,
+  List.In n (iota m len) -> Nat.lt n (Nat.add m len).
+Proof.
+  induction len; intros m n Hin; cbn in Hin; first by [].
+  destruct Hin as [->|Hin]; first lia.
+  apply IHlen in Hin. lia.
+Qed.
+
+(* A write that lies entirely above the read range doesn't affect the read. *)
+Lemma write_bytes_read_bytes_ne : forall mt md addr bs m0 a len,
+  write_bytes md addr bs = Some m0 ->
+  (a + N.of_nat len <= addr)%N ->
+  read_bytes {| meminst_type := mt; meminst_data := m0 |} a len
+  = read_bytes {| meminst_type := mt; meminst_data := md |} a len.
+Proof.
+  intros mt md addr bs m0 a len Hw Hdisj.
+  unfold read_bytes. cbn. f_equal.
+  apply map_ext_in. intros off Hin.
+  apply in_iota_lt in Hin. cbn in Hin.
+  unfold write_bytes, write_bytes_gen in Hw.
+  apply: mem_update_gen_lookup_lt; first exact Hw.
+  lia.
+Qed.
+
 Lemma write_bytes_read_bytes_i32 : forall m addr v m0,
   length v = 4 ->
   write_bytes (meminst_data m) addr (bytes_takefill #00 4 v) = Some m0 ->
   read_bytes {| meminst_type := meminst_type m; meminst_data := m0 |} addr 4 = Some v.
 Proof.
-  intros. do 5 destruct v=>//. cbn in H0.
-  rewrite -!N.add_assoc in H0. cbn in H0.
-  destruct (mem_update addr _ _) eqn:Hu1=>//.
-  destruct (mem_update (addr + 1) _ _) eqn:Hu2=>//.
-  destruct (mem_update (addr + 2) _ _) eqn:Hu3=>//.
-  destruct (mem_update (addr + 3) _ _) eqn:Hu4=>//. inv H0.
-  unfold read_bytes, those. cbn.
-  replace (mem_lookup (addr + 3) m0) with (Some b2).
-  2:{ now apply mem_update_lookup in Hu4. }
-
-  replace (mem_lookup (addr + 2) m0) with (Some b1).
-  2:{ apply mem_update_lookup in Hu3.
-      erewrite mem_update_lookup_ne; eauto. lia. }
-
-  replace (mem_lookup (addr + 1) m0) with (Some b0).
-  2:{ apply mem_update_lookup_ne with (i:=(addr + 1)%N) in Hu4, Hu3; try lia.
-      rewrite Hu4 Hu3. now erewrite mem_update_lookup. }
-
-  replace (addr + 0)%N with addr by lia.
-  replace (mem_lookup addr m0) with (Some b).
-  2: { apply mem_update_lookup_ne with (i:=addr) in Hu4, Hu3, Hu2; try lia.
-       rewrite Hu4 Hu3 Hu2. now erewrite mem_update_lookup. }
-  reflexivity.
+  intros m addr v m0 Hlen Hw.
+  rewrite (bytes_takefill_id _ _ Hlen) in Hw.
+  have Hres : read_bytes {| meminst_type := meminst_type m; meminst_data := m0 |}
+                addr (length v) = Some v
+    by apply: write_bytes_read_bytes; exact Hw.
+  by rewrite Hlen in Hres.
 Qed.
 
 Lemma store_load_i32 : forall m m' addr v,
@@ -1145,50 +1185,12 @@ Lemma write_bytes_read_bytes_i64 : forall m addr v m0,
   write_bytes (meminst_data m) addr (bytes_takefill #00 8 v) = Some m0 ->
   read_bytes {| meminst_type := meminst_type m; meminst_data := m0 |} addr 8 = Some v.
 Proof.
-  intros. do 9 destruct v=>//. cbn in H0.
-  rewrite -!N.add_assoc in H0. cbn in H0.
-  destruct (mem_update addr _ _) eqn:Hu1=>//.
-  destruct (mem_update (addr + 1) _ _) eqn:Hu2=>//.
-  destruct (mem_update (addr + 2) _ _) eqn:Hu3=>//.
-  destruct (mem_update (addr + 3) _ _) eqn:Hu4=>//.
-  destruct (mem_update (addr + 4) _ _) eqn:Hu5=>//.
-  destruct (mem_update (addr + 5) _ _) eqn:Hu6=>//.
-  destruct (mem_update (addr + 6) _ _) eqn:Hu7=>//.
-  destruct (mem_update (addr + 7) _ _) eqn:Hu8=>//. inv H0.
-  unfold read_bytes, those. cbn.
-  replace (mem_lookup (addr + 7) m0) with (Some b6).
-  2:{ now eapply mem_update_lookup in Hu8. }
-
-  replace (mem_lookup (addr + 6) m0) with (Some b5).
-  2:{ apply mem_update_lookup_ne with (i:=(addr + 6)%N) in Hu8.
-      rewrite Hu8. now erewrite mem_update_lookup. lia. }
-
-  replace (mem_lookup (addr + 5) m0) with (Some b4).
-  2:{ apply mem_update_lookup_ne with (i:=(addr + 5)%N) in Hu8, Hu7; try lia.
-      rewrite Hu8 Hu7. now erewrite mem_update_lookup. }
-
-  replace (mem_lookup (addr + 4) m0) with (Some b3).
-  2:{ apply mem_update_lookup_ne with (i:=(addr + 4)%N) in Hu8, Hu7, Hu6; try lia.
-      rewrite Hu8 Hu7 Hu6. now erewrite mem_update_lookup. }
-
-  replace (mem_lookup (addr + 3) m0) with (Some b2).
-  2:{ apply mem_update_lookup_ne with (i:=(addr + 3)%N) in Hu8, Hu7, Hu6, Hu5; try lia.
-      rewrite Hu8 Hu7 Hu6 Hu5. now erewrite mem_update_lookup. }
-
-  replace (mem_lookup (addr + 2) m0) with (Some b1).
-  2:{ apply mem_update_lookup_ne with (i:=(addr + 2)%N) in Hu8, Hu7, Hu6, Hu5, Hu4;
-        try lia.
-      rewrite Hu8 Hu7 Hu6 Hu5 Hu4. now erewrite mem_update_lookup. }
-
-  replace (mem_lookup (addr + 1) m0) with (Some b0).
-  2:{ apply mem_update_lookup_ne with (i:=(addr + 1)%N) in Hu8, Hu7, Hu6, Hu5, Hu4, Hu3; try lia.
-      rewrite Hu8 Hu7 Hu6 Hu5 Hu4 Hu3. now erewrite mem_update_lookup. }
-
-  replace (addr + 0)%N with addr by lia.
-  replace (mem_lookup addr m0) with (Some b).
-  2: { apply mem_update_lookup_ne with (i:=addr) in Hu8, Hu7, Hu6, Hu5, Hu4, Hu3, Hu2; try lia.
-       rewrite Hu8 Hu7 Hu6 Hu5 Hu4 Hu3 Hu2. now erewrite mem_update_lookup. }
-  reflexivity.
+  intros m addr v m0 Hlen Hw.
+  rewrite (bytes_takefill_id _ _ Hlen) in Hw.
+  have Hres : read_bytes {| meminst_type := meminst_type m; meminst_data := m0 |}
+                addr (length v) = Some v
+    by apply: write_bytes_read_bytes; exact Hw.
+  by rewrite Hlen in Hres.
 Qed.
 
 Lemma store_load_i64 : forall m m' addr v,
@@ -1381,40 +1383,17 @@ Lemma load_store_load_i32 : forall m m' a1 a2 v w,
   store m a2 0%N w 4 = Some m' ->
   load_i32 m' a1 = Some v.
 Proof.
-  unfold store, load_i32, load, write_bytes_meminst. intros.
-  do 5 destruct w=>//.
-  destruct (a2 + 0 + N.of_nat 4 <=? mem_length m)%N eqn:Hlen=>//.
-  destruct (a1 + (0 + 4) <=? mem_length m)%N eqn:Hlen'=>//.
-  destruct (read_bytes _ _ _) eqn:Hread=>//.
-  destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv H2. inv H1.
-  have Hlen'' := write_bytes_gen_preserve_length Hwrite.
-  unfold mem_length. cbn. rewrite -Hlen'' Hlen'.
-  unfold read_bytes, those in *. cbn. rewrite -!N.add_assoc. cbn.
-  cbn in Hread. rewrite -!N.add_assoc in Hread. cbn in Hread.
-  destruct (mem_lookup (a1 + 0) _) eqn:Hl0=>//.
-  destruct (mem_lookup (a1 + 1) _) eqn:Hl1=>//.
-  destruct (mem_lookup (a1 + 2) _) eqn:Hl2=>//.
-  destruct (mem_lookup (a1 + 3) _) eqn:Hl3=>//. inv Hread.
-
-  cbn in Hwrite. rewrite -!N.add_assoc in Hwrite. cbn in Hwrite.
-  destruct (mem_update (a2 + 0) _ _) eqn:Hu0=>//.
-  destruct (mem_update (a2 + 1) _ _) eqn:Hu1=>//.
-  destruct (mem_update (a2 + 2) _ _) eqn:Hu2=>//.
-  destruct (mem_update (a2 + 3) _ _) eqn:Hu3=>//. inv Hwrite.
-
-  replace (mem_lookup (a1 + 0) m0) with (Some b4).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+0)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-
-  replace (mem_lookup (a1 + 1) m0) with (Some b5).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+1)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-
-  replace (mem_lookup (a1 + 2) m0) with (Some b6).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+2)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-
-  replace (mem_lookup (a1 + 3) m0) with (Some b7).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+3)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-
-  reflexivity.
+  intros m m' a1 a2 v w Hlw Hdisj Hload Hstore.
+  unfold store, write_bytes_meminst in Hstore.
+  destruct (_ <=? _)%N eqn:Hlen=>//.
+  destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv Hstore.
+  have Hlen' := write_bytes_gen_preserve_length Hwrite.
+  unfold load_i32, load in *.
+  replace (mem_length {| meminst_type := meminst_type m; meminst_data := m0 |})
+     with (mem_length m) by (unfold mem_length; cbn; congruence).
+  destruct (_ <=? _)%N eqn:Hlen2=>//.
+  rewrite (write_bytes_read_bytes_ne _ _ _ _ _ _ _ Hwrite); last (cbn; lia).
+  exact Hload.
 Qed.
 
 
@@ -1429,41 +1408,17 @@ Lemma load_store_load_i32' : forall m m' a1 a2 v w,
   store m a2 0%N w 8 = Some m' ->
   load_i32 m' a1 = Some v.
 Proof.
-  unfold store, load_i32, load, write_bytes_meminst. intros.
-  do 9 destruct w=>//.
-  destruct (a2 + 0 + N.of_nat 8 <=? mem_length m)%N eqn:Hlen=>//.
-  destruct (a1 + (0 + 4) <=? mem_length m)%N eqn:Hlen'=>//.
-  destruct (read_bytes _ _ _) eqn:Hread=>//.
-  destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv H2. inv H1.
-  have Hlen'' := write_bytes_gen_preserve_length Hwrite.
-  unfold mem_length. cbn. rewrite -Hlen'' Hlen'.
-  unfold read_bytes, those in *. cbn. rewrite -!N.add_assoc. cbn.
-  cbn in Hread. rewrite -!N.add_assoc in Hread. cbn in Hread.
-  destruct (mem_lookup (a1 + 0) _) eqn:Hl0=>//.
-  destruct (mem_lookup (a1 + 1) _) eqn:Hl1=>//.
-  destruct (mem_lookup (a1 + 2) _) eqn:Hl2=>//.
-  destruct (mem_lookup (a1 + 3) _) eqn:Hl3=>//. inv Hread.
-
-  cbn in Hwrite. rewrite -!N.add_assoc in Hwrite. cbn in Hwrite.
-  destruct (mem_update (a2 + 0) _ _) eqn:Hu0=>//.
-  destruct (mem_update (a2 + 1) _ _) eqn:Hu1=>//.
-  destruct (mem_update (a2 + 2) _ _) eqn:Hu2=>//.
-  destruct (mem_update (a2 + 3) _ _) eqn:Hu3=>//.
-  destruct (mem_update (a2 + 4) _ _) eqn:Hu4=>//.
-  destruct (mem_update (a2 + 5) _ _) eqn:Hu5=>//.
-  destruct (mem_update (a2 + 6) _ _) eqn:Hu6=>//.
-  destruct (mem_update (a2 + 7) _ _) eqn:Hu7=>//. inv Hwrite.
-
-  replace (mem_lookup (a1 + 0) m0) with (Some b8).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+0)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 1) m0) with (Some b9).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+1)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 2) m0) with (Some b10).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+2)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 3) m0) with (Some b11).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+3)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-
-  reflexivity.
+  intros m m' a1 a2 v w Hlw Hdisj Hload Hstore.
+  unfold store, write_bytes_meminst in Hstore.
+  destruct (_ <=? _)%N eqn:Hlen=>//.
+  destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv Hstore.
+  have Hlen' := write_bytes_gen_preserve_length Hwrite.
+  unfold load_i32, load in *.
+  replace (mem_length {| meminst_type := meminst_type m; meminst_data := m0 |})
+     with (mem_length m) by (unfold mem_length; cbn; congruence).
+  destruct (_ <=? _)%N eqn:Hlen2=>//.
+  rewrite (write_bytes_read_bytes_ne _ _ _ _ _ _ _ Hwrite); last (cbn; lia).
+  exact Hload.
 Qed.
 
 
@@ -1474,49 +1429,17 @@ Lemma load_store_load_i64 : forall m m' a1 a2 v w,
   store m a2 0%N w 4 = Some m' ->
   load_i64 m' a1 = Some v.
 Proof.
-  unfold store, load_i32, load_i64, load, write_bytes_meminst. intros.
-  do 5 destruct w=>//.
-  destruct (a2 + 0 + N.of_nat 4 <=? mem_length m)%N eqn:Hlen=>//.
-  destruct (a1 + (0 + 8) <=? mem_length m)%N eqn:Hlen'=>//.
-  destruct (read_bytes _ _ _) eqn:Hread=>//.
-  destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv H2. inv H1.
-  have Hlen'' := write_bytes_gen_preserve_length Hwrite.
-  unfold mem_length. cbn. rewrite -Hlen'' Hlen'.
-  unfold read_bytes, those in *. cbn. rewrite -!N.add_assoc. cbn.
-  cbn in Hread. rewrite -!N.add_assoc in Hread. cbn in Hread.
-  destruct (mem_lookup (a1 + 0) _) eqn:Hl0=>//.
-  destruct (mem_lookup (a1 + 1) _) eqn:Hl1=>//.
-  destruct (mem_lookup (a1 + 2) _) eqn:Hl2=>//.
-  destruct (mem_lookup (a1 + 3) _) eqn:Hl3=>//.
-  destruct (mem_lookup (a1 + 4) _) eqn:Hl4=>//.
-  destruct (mem_lookup (a1 + 5) _) eqn:Hl5=>//.
-  destruct (mem_lookup (a1 + 6) _) eqn:Hl6=>//.
-  destruct (mem_lookup (a1 + 7) _) eqn:Hl7=>//. inv Hread.
-
-  cbn in Hwrite. rewrite -!N.add_assoc in Hwrite. cbn in Hwrite.
-  destruct (mem_update (a2 + 0) _ _) eqn:Hu0=>//.
-  destruct (mem_update (a2 + 1) _ _) eqn:Hu1=>//.
-  destruct (mem_update (a2 + 2) _ _) eqn:Hu2=>//.
-  destruct (mem_update (a2 + 3) _ _) eqn:Hu3=>//. inv Hwrite.
-
-  replace (mem_lookup (a1 + 0) m0) with (Some b4).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+0)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-  replace (mem_lookup (a1 + 1) m0) with (Some b5).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+1)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-  replace (mem_lookup (a1 + 2) m0) with (Some b6).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+2)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-  replace (mem_lookup (a1 + 3) m0) with (Some b7).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+3)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-  replace (mem_lookup (a1 + 4) m0) with (Some b8).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+4)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-  replace (mem_lookup (a1 + 5) m0) with (Some b9).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+5)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-  replace (mem_lookup (a1 + 6) m0) with (Some b10).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+6)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-  replace (mem_lookup (a1 + 7) m0) with (Some b11).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+7)%N) in Hu0, Hu1, Hu2, Hu3; try lia. congruence. }
-
-  reflexivity.
+  intros m m' a1 a2 v w Hlw Hdisj Hload Hstore.
+  unfold store, write_bytes_meminst in Hstore.
+  destruct (_ <=? _)%N eqn:Hlen=>//.
+  destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv Hstore.
+  have Hlen' := write_bytes_gen_preserve_length Hwrite.
+  unfold load_i64, load in *.
+  replace (mem_length {| meminst_type := meminst_type m; meminst_data := m0 |})
+     with (mem_length m) by (unfold mem_length; cbn; congruence).
+  destruct (_ <=? _)%N eqn:Hlen2=>//.
+  rewrite (write_bytes_read_bytes_ne _ _ _ _ _ _ _ Hwrite); last (cbn; lia).
+  exact Hload.
 Qed.
 
 Lemma load_store_load_i64' : forall m m' a1 a2 v w,
@@ -1526,53 +1449,17 @@ Lemma load_store_load_i64' : forall m m' a1 a2 v w,
   store m a2 0%N w 8 = Some m' ->
   load_i64 m' a1 = Some v.
 Proof.
-  unfold store, load_i32, load_i64, load, write_bytes_meminst. intros.
-  do 9 destruct w=>//.
-  destruct (a2 + 0 + N.of_nat 8 <=? mem_length m)%N eqn:Hlen=>//.
-  destruct (a1 + (0 + 8) <=? mem_length m)%N eqn:Hlen'=>//.
-  destruct (read_bytes _ _ _) eqn:Hread=>//.
-  destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv H2. inv H1.
-  have Hlen'' := write_bytes_gen_preserve_length Hwrite.
-  unfold mem_length. cbn. rewrite -Hlen'' Hlen'.
-  unfold read_bytes, those in *. cbn. rewrite -!N.add_assoc. cbn.
-  cbn in Hread. rewrite -!N.add_assoc in Hread. cbn in Hread.
-  destruct (mem_lookup (a1 + 0) _) eqn:Hl0=>//.
-  destruct (mem_lookup (a1 + 1) _) eqn:Hl1=>//.
-  destruct (mem_lookup (a1 + 2) _) eqn:Hl2=>//.
-  destruct (mem_lookup (a1 + 3) _) eqn:Hl3=>//.
-  destruct (mem_lookup (a1 + 4) _) eqn:Hl4=>//.
-  destruct (mem_lookup (a1 + 5) _) eqn:Hl5=>//.
-  destruct (mem_lookup (a1 + 6) _) eqn:Hl6=>//.
-  destruct (mem_lookup (a1 + 7) _) eqn:Hl7=>//. inv Hread.
-
-  cbn in Hwrite. rewrite -!N.add_assoc in Hwrite. cbn in Hwrite.
-  destruct (mem_update (a2 + 0) _ _) eqn:Hu0=>//.
-  destruct (mem_update (a2 + 1) _ _) eqn:Hu1=>//.
-  destruct (mem_update (a2 + 2) _ _) eqn:Hu2=>//.
-  destruct (mem_update (a2 + 3) _ _) eqn:Hu3=>//.
-  destruct (mem_update (a2 + 4) _ _) eqn:Hu4=>//.
-  destruct (mem_update (a2 + 5) _ _) eqn:Hu5=>//.
-  destruct (mem_update (a2 + 6) _ _) eqn:Hu6=>//.
-  destruct (mem_update (a2 + 7) _ _) eqn:Hu7=>//. inv Hwrite.
-
-  replace (mem_lookup (a1 + 0) m0) with (Some b8).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+0)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 1) m0) with (Some b9).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+1)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 2) m0) with (Some b10).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+2)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 3) m0) with (Some b11).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+3)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 4) m0) with (Some b12).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+4)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 5) m0) with (Some b13).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+5)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 6) m0) with (Some b14).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+6)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-  replace (mem_lookup (a1 + 7) m0) with (Some b15).
-  2:{ apply mem_update_lookup_ne with (i:=(a1+7)%N) in Hu0, Hu1, Hu2, Hu3, Hu4, Hu5, Hu6, Hu7; try lia. congruence. }
-
-  reflexivity.
+  intros m m' a1 a2 v w Hlw Hdisj Hload Hstore.
+  unfold store, write_bytes_meminst in Hstore.
+  destruct (_ <=? _)%N eqn:Hlen=>//.
+  destruct (write_bytes _ _ _) eqn:Hwrite=>//. inv Hstore.
+  have Hlen' := write_bytes_gen_preserve_length Hwrite.
+  unfold load_i64, load in *.
+  replace (mem_length {| meminst_type := meminst_type m; meminst_data := m0 |})
+     with (mem_length m) by (unfold mem_length; cbn; congruence).
+  destruct (_ <=? _)%N eqn:Hlen2=>//.
+  rewrite (write_bytes_read_bytes_ne _ _ _ _ _ _ _ Hwrite); last (cbn; lia).
+  exact Hload.
 Qed.
 
 
@@ -1941,6 +1828,12 @@ Proof. now unfold Int64.modulus, Int64.half_modulus, two_power_nat. Qed.
 
 Hint Resolve int64_modulus_eq_pow64 : core.
 
+(* WasmCert defines the shift operations as [shl i1 (modu i2 iwordsize)];
+   normalise the shift amount to a literal modulus. *)
+Lemma int64_modu_iwordsize : forall i,
+  Int64.modu i Int64.iwordsize = Int64.repr (Int64.unsigned i mod 64).
+Proof. intros. unfold Int64.modu. now do 2 f_equal. Qed.
+
 Lemma uint63_lt_pow64 : forall (x : uint63), (0 <= to_Z x < 2^64)%Z.
 Proof.
   intros; have H := (to_Z_bounded x).
@@ -2157,10 +2050,10 @@ Lemma uint63_lsl_i64_shl : forall x y,
 Proof.
   intros.
   have H' := to_Z_bounded y.
-  unfold Int64.ishl, Int64.shl, Int64.wordsize, Integers.Wordsize_64.wordsize.
+  unfold Int64.ishl, Int64.shl. rewrite int64_modu_iwordsize.
   replace (to_Z 63) with 63%Z in H by now cbn.
   do 2 rewrite uint63_unsigned_id.
-  replace (Int64.unsigned (Z_to_i64 (to_Z y mod 64%nat))) with (to_Z y). 2: now rewrite Z.mod_small; [rewrite uint63_unsigned_id|].
+  replace (Int64.unsigned (Z_to_i64 (to_Z y mod 64))) with (to_Z y). 2: now rewrite Z.mod_small; [rewrite uint63_unsigned_id|].
   rewrite Z.shiftl_mul_pow2. 2: lia.
   now rewrite lsl_spec; rewrite int64_bitmask_modulo.
 Qed.
@@ -2180,10 +2073,10 @@ Lemma uint63_lsr_i64_shr : forall x y,
 Proof.
   intros.
   have H' := to_Z_bounded y.
-  unfold Int64.ishr_u, Int64.shru, Int64.wordsize, Integers.Wordsize_64.wordsize.
+  unfold Int64.ishr_u, Int64.shru. rewrite int64_modu_iwordsize.
   replace (to_Z 63) with 63%Z in H by now cbn.
   do 2 rewrite uint63_unsigned_id.
-  replace (Int64.unsigned (Z_to_i64 (to_Z y mod 64%nat))) with (to_Z y).
+  replace (Int64.unsigned (Z_to_i64 (to_Z y mod 64))) with (to_Z y).
   2: now rewrite Z.mod_small; [rewrite uint63_unsigned_id|].
   rewrite Z.shiftr_div_pow2. 2: lia.
   now rewrite lsr_spec.
@@ -2272,8 +2165,8 @@ Lemma int64_high32 : forall x,
   Int64.ishr_u x 32 = (x / 2^32)%Z.
 Proof.
 intros.
-unfold Int64.ishr_u, Int64.shru.
-replace (Int64.unsigned (Z_to_i64 (Int64.unsigned 32 mod Int64.wordsize))) with (Int64.unsigned 32%Z) by now cbn.
+unfold Int64.ishr_u, Int64.shru. rewrite int64_modu_iwordsize.
+replace (Int64.unsigned (Z_to_i64 (Int64.unsigned 32 mod 64))) with (Int64.unsigned 32%Z) by now cbn.
 replace (Int64.unsigned x) with x; auto.
 replace (Int64.unsigned 32%Z) with 32%Z; auto.
 now rewrite Z.shiftr_div_pow2; auto.
@@ -2481,9 +2374,9 @@ Lemma upper_shifted_i64 : forall x y,
   Int64.ishl (Int64.repr (upper x y)) (Int64.repr 1) = Int64.repr (upper x y * 2)%Z.
 Proof.
   intros ?? Hx Hy. have H := upper_range x y Hx Hy.
-  unfold Int64.ishl, Int64.shl.
+  unfold Int64.ishl, Int64.shl. rewrite int64_modu_iwordsize.
   repeat rewrite lt_pow64_unsigned_id.
-  replace (1 mod Int64.wordsize)%Z with 1%Z by now cbn.
+  replace (1 mod 64)%Z with 1%Z by now cbn.
   rewrite Z.shiftl_mul_pow2. f_equal. lia.
   all: cbn; lia.
 Qed.
@@ -2518,10 +2411,10 @@ Lemma lower_shifted_i64 : forall x y,
     Int64.repr ((lower x y) mod 2^64 / 2^63).
 Proof.
   intros ?? Hx Hy.
-  unfold Int64.ishr_u, Int64.shru.
+  unfold Int64.ishr_u, Int64.shru. rewrite int64_modu_iwordsize.
   replace (Int64.unsigned (Int64.repr (lower x y))) with ((lower x y) mod 2^64)%Z.
   repeat rewrite lt_pow64_unsigned_id.
-  replace (63 mod Int64.wordsize)%Z with 63%Z by now cbn.
+  replace (63 mod 64)%Z with 63%Z by now cbn.
   rewrite Z.shiftr_div_pow2. reflexivity.
   lia. lia. cbn; lia. lia.
   cbn. rewrite Int64.Z_mod_modulus_eq. now rewrite int64_modulus_eq_pow64.
@@ -2655,7 +2548,7 @@ Qed.
 (* head0 related *)
 
 Lemma head0_spec_alt: forall x : uint63,
-  (0 < φ (x)%uint63)%Z ->
+  (0 < to_Z x)%Z ->
   (to_Z (head0 x) = 62 - Z.log2 (to_Z x))%Z.
 Proof.
   intros.
@@ -3168,7 +3061,7 @@ Proof.
   intros.
   unfold Int64.unsigned.
   rewrite clz_spec_alt.
-  replace (63 - Z.log2 (Int64.intval (Z_to_i64 φ (x)%uint63)) - 1)%Z with (62 - Z.log2 (Int64.intval (Z_to_i64 φ (x)%uint63)))%Z by lia.
+  replace (63 - Z.log2 (Int64.intval (Z_to_i64 (to_Z x))) - 1)%Z with (62 - Z.log2 (Int64.intval (Z_to_i64 (to_Z x))))%Z by lia.
   replace (Int64.intval (Z_to_i64 (to_Z x))) with (to_Z  x). rewrite head0_spec_alt; auto.
   simpl. rewrite uint63_mod_modulus_id.
   reflexivity. auto.
@@ -3467,7 +3360,7 @@ Proof.
   assert (to_Z (tail0 x) = Int64.unsigned (Int64.ctz (Int64.repr (to_Z x)))). {
     apply unique_greatest_power_of_two_divisor with (x:=to_Z x); auto.
     destruct (to_Z_bounded (tail0 x)). lia.
-    destruct (Int64.unsigned_range (Int64.ctz (Z_to_i64 φ (x)%uint63))). lia.
+    destruct (Int64.unsigned_range (Int64.ctz (Z_to_i64 (to_Z x)))). lia.
     destruct Htail0 as [y [_ Hy]]. exists y. auto.
     destruct Hctz as [y Hy]. rewrite - [(y * 2)%Z] Z.mul_comm in Hy.
     exists y; auto. }

--- a/theories/Compiler/metarocq_pipeline.v
+++ b/theories/Compiler/metarocq_pipeline.v
@@ -43,10 +43,10 @@ Program Definition certirocq_post_metarocq_pipeline econf : Transform.t global_c
       (has_app := eq_refl) (has_rel := eq_refl) (has_pars := eq_refl) (has_cstrblocks := eq_refl) ▷
   consts_to_values_transformation efl' final_wcbv_flags eq_refl eq_refl eq_refl ▷
   (* Lazy-to-lambda *)
-  implement_lazy_force_transformation efl' eq_refl eq_refl eq_refl eq_refl eq_refl ▷
+  implement_lazy_force_transformation efl' eq_refl eq_refl eq_refl eq_refl eq_refl false ▷
   rebuild_wf_env_transform (efl := efl'') false false ▷
   unbox_transformation efl'' final_wcbv_flags (has_app := _) (has_cofix := _) (has_prop_case := eq_refl) (has_letin := eq_refl) (has_cstrparams := eq_refl) (has_cstr_block := eq_refl) ▷
-  implement_box_transformation efl'' eq_refl eq_refl eq_refl eq_refl eq_refl ▷
+  implement_box_transformation efl'' eq_refl eq_refl eq_refl eq_refl eq_refl false ▷
   ETransform.optional_self_transform econf.(enable_unsafe).(inductives_extraction)
     (rebuild_wf_env_transform (efl := efl''') false false ▷
        extract_inductive_transformation efl''' final_wcbv_flags econf.(extracted_inductives) ▷

--- a/theories/LambdaANF/PrototypeGenFrame.v
+++ b/theories/LambdaANF/PrototypeGenFrame.v
@@ -607,7 +607,7 @@ Definition gen_univ_univD (qual : modpath) (typename : kername) (g : mind_graph_
     mind_entry_finite := Finite;
     mind_entry_params := [];
     mind_entry_inds := [ind_entry];
-    mind_entry_universes := Monomorphic_entry (LevelSet.empty, ConstraintSet.empty);
+    mind_entry_universes := Monomorphic_entry;
     mind_entry_template := false;
     mind_entry_variance := None;
     mind_entry_private := None |}, ty_ns, (qual, snd typename +++ "_univD"), body).
@@ -683,7 +683,7 @@ Definition gen_frame_t (qual : modpath) (typename : kername) (inds : ind_info) (
     mind_entry_finite := Finite;
     mind_entry_params := [];
     mind_entry_inds := [ind_entry];
-    mind_entry_universes := Monomorphic_entry (LevelSet.empty, ConstraintSet.empty);
+    mind_entry_universes := Monomorphic_entry;
     mind_entry_template := false;
     mind_entry_variance := None;
     mind_entry_private := None |}.

--- a/theories/LambdaANF/closure_conversion_util.v
+++ b/theories/LambdaANF/closure_conversion_util.v
@@ -1298,7 +1298,7 @@ Section Closure_conversion_util.
       eapply Union_Included; [| now xsets ].
       eapply Union_Included; [| now xsets ]. xsets.
     - eapply project_var_occurs_free_ctx_Included_no_env; eauto.
-      normalize_occurs_free... now sets. now sets.
+      normalize_occurs_free. now sets. now sets.
 
       Unshelve. exact (Empty_set _).
   Qed.

--- a/theories/LambdaANF/lambda_lifting_util.v
+++ b/theories/LambdaANF/lambda_lifting_util.v
@@ -323,7 +323,7 @@ Proof.
     inv H0; eauto.
     eapply Disjoint_Included; [| | now apply IHHadd ].
     rewrite lifted_name_extend. rewrite image_extend_not_In_S; eauto.
-    apply image_monotonic...
+    apply image_monotonic.
     now eauto with Ensembles_DB.
     rewrite lifted_name_extend. rewrite image_extend_not_In_S; eauto.
     reflexivity. intros Hc. eapply H6.


### PR DESCRIPTION
`main` no longer builds against a current Rocq dev switch. This is ten
independent adaptations, each in its own commit with the reason in the commit
message; none of them changes what any definition or theorem says.

### Rocq

* **`Replace two orphan "..." end-tac markers with "."`** — `tac...` runs the
  end tactic declared by `Proof with`. The two sites in
  `LambdaANF/closure_conversion_util.v` sit in proofs opened with a plain
  `Proof.`, so the `...` expanded to nothing. Since Rocq 9.2 (rocq-prover/rocq
  `36b70cc218`) that is a hard error rather than a silent no-op. The two uses
  that *are* inside `Proof with` blocks are left alone.

* **`Use Tacinterp.Value.apply instead of a hand-rolled ltac_apply`** — the
  OCaml type of a `tactic(tac)` argument in `TACTIC EXTEND` is now
  `Ltac_plugin.Tacarg.tacvalue` rather than `Tacinterp.Value.t`, so passing it
  to the local `ltac_apply` no longer typechecks. `Tacinterp.Value.apply`
  does exactly what `ltac_apply` did; MetaRocq's template plugin already calls
  it. The two dead helpers go away.

### MetaRocq

* **`Monomorphic_entry no longer takes a ContextSet argument`** — the two
  construction sites in `PrototypeGenFrame.v` both passed the empty context
  set, so dropping the argument is meaning-preserving.

* **`Pass pres_values to implement_lazy_force/implement_box transformations`**
  — `implement_lazy_force_transformation` and `implement_box_transformation`
  gained a trailing `pres_values : bool` in MetaRocq 9.1's `dd8d7fe4`, gating a
  `values_glob` / `lambda_glob` conjunct in the pre- and postconditions.
  Passing `false` makes both conditions `True`, which reproduces the previous
  pre/post exactly.

### WasmCert

WasmCert reimplemented `write_bytes` on top of the `BlockUpdateMemory` class
in `094d41d` ("added implementation for persistent array updates with block
generators"), which is after the `v2.2.0` tag this package pins. `write_bytes
m i bs` is now `write_bytes_gen m i (N.of_nat (length bs)) gen`, i.e. a single
bulk `mem_update_gen`, not a fold of per-byte `mem_update`s.

* **`write_bytes_preserve_length is now write_bytes_gen_preserve_length`** and
  **`rename the remaining write_bytes_preserve_length uses`** — a pure rename
  at six sites; `write_bytes` is transparent, so the `_gen` lemma unifies with
  a `write_bytes … = Some m'` hypothesis by delta.

* **`reprove enough_space_to_store against block memory updates`** — the old
  proof peeled off one `mem_update` per byte by induction on `bs`; after `cbn`
  there is no longer a `mem_update` application in the goal at all.
  `mem_update_gen_ib` gives the non-`None` result directly from
  `n + len <= mem_length m`, which is exactly the hypothesis, so the induction
  goes away.

* **`port the remaining memory/int64 lemmas to current WasmCert`** — the four
  `load_store_load_i32/i64(')` proofs destructed the same per-byte chain.
  They are replaced by one `write_bytes_read_bytes_ne` lemma ("a write that
  lies entirely above the read range does not affect the read"), derived from
  `mem_update_gen_lookup_lt`; each of the four proofs is then twelve uniform
  lines. This commit also handles two unrelated drifts: `Wasm_int.Int64.ishl`
  and `ishr_u` now compute the shift amount as `modu i2 iwordsize` instead of
  inlining the modulus (new helper `int64_modu_iwordsize` normalises it back
  to a literal `64`), and `Uint63` only opens `uint63_scope` `#[local]` now,
  so the `φ` notation is not in scope for importers — spelled `to_Z`, which
  the rest of the file already used.

* **`three more small adaptations`** — `LambdaANF_to_Wasm_primitives_correct`
  imported `Wasm.memory_list` without using anything from it; now that
  `meminst` is indexed by a `Memory` instance, that import puts `Memory_list`
  in scope and typeclass resolution picks it over the section's
  `memory_from_bum`, so `local_holds_address_to_i64`'s `(m : meminst)` stops
  typechecking. Also `rewrite map_nth` now resolves to mathcomp's
  `seq.map_nth` rather than `List.map_nth`, and `rewrite head00_spec` no
  longer infers its argument.

### Build

* **`bootstrap: raise the stack limit for the certirocqc self-compilation`** —
  `CertiRocq Compile certirocqc` in `bootstrap/certirocqc/theories/compile.v`
  overflows the OCaml stack at the usual 8 MB soft limit, after about 160 s in
  the LambdaANF pipeline. The `test.vo` rules in this Makefile and in
  `bootstrap/certirocqchk/Makefile` already raise the limit; the `compile.vo`
  rule now does too, falling back to the hard limit and then to doing nothing,
  so it still runs where the hard limit is finite.

### Status

With this branch, `opam install rocq-certirocq` succeeds on a Rocq dev switch:
all four recipe steps — `./configure.sh`, `make all`, `make plugins`,
`make bootstrap` — complete, including the certirocqc and certirocqchk
self-compilations.

That needs MetaRocq `main` to carry the erasure work that so far exists only on
the `9.1` branch: `EConstantsToValues`, `EImplementLazyForce`, and
`ETransform.v`'s `efl_coind_to_ind`, `consts_to_values_transformation`,
`implement_box_transformation`, `implement_lazy_force_transformation`. That is
MetaRocq/metarocq#1297, and this branch was verified against it. Until it lands,
`Compiler/metarocq_pipeline.v` and the three files behind it
(`Compiler/pipeline.v`, `Extraction/extraction.v`,
`ExtractionVanilla/extraction.v`) will still fail here with

```
Error: The reference efl_coind_to_ind was not found in the current environment.
```

The in-tree `rocq-certirocq.opam` is not touched here — that is #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b
